### PR TITLE
Fix: Ensure REST Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 
 ## 1.0.0 (Initial Release)
 * Convert & Export Blocks to JSON.
-* Custom Hooks - `cbtj_rest_response`.
+* Custom Hooks - `cbtj_rest_export`.
 * Provided support for Arabic, Chinese, Hebrew, Hindi, Russian, German, Italian, Croatian, Spanish & French languages.
 * Unit Tests coverage.
 * Tested up to WP 6.6.1.

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ https://github.com/user-attachments/assets/9dedf30f-9df0-4307-b634-cecef930a6e5
 
 ### Hooks
 
-#### `cbtj_rest_response`
+#### `cbtj_rest_export`
 
 This custom hook (filter) provides the ability to customise the REST response obtained:
 
 ```php
-add_filter( 'cbtj_rest_response', [ $this, 'custom_rest_response' ], 10, 2 );
+add_filter( 'cbtj_rest_export', [ $this, 'custom_rest_export' ], 10, 2 );
 
-public function custom_rest_response( $response, $post_id ): array {
+public function custom_rest_export( $response, $post_id ): array {
     $response['content'] = wp_parse_args(
         [
             'name'    => 'custom/post-meta-block',

--- a/convert-blocks-to-json.php
+++ b/convert-blocks-to-json.php
@@ -80,37 +80,6 @@ add_action( 'init', function() {
 } );
 
 /**
- * Setup REST routes.
- *
- * @since 1.0.0
- * @since 1.0.1 Added `import` REST endpoint.
- * @since 1.0.2 Serve is_user_permissible for permissions.
- *
- * @wp-hook 'rest_api_init'
- */
-add_action( 'rest_api_init', function() {
-	register_rest_route(
-		'cbtj/v1',
-		'/(?P<id>\d+)',
-		[
-			'methods'             => \WP_REST_Server::READABLE,
-			'callback'            => __NAMESPACE__ . '\get_rest_response',
-			'permission_callback' => '__return_true',
-		]
-	);
-
-	register_rest_route(
-		'cbtj/v1',
-		'/import',
-		[
-			'methods'             => \WP_REST_Server::CREATABLE,
-			'callback'            => __NAMESPACE__ . '\get_json_import',
-			'permission_callback' => __NAMESPACE__ . '\is_user_permissible',
-		]
-	);
-} );
-
-/**
  * Register Mimes.
  *
  * @since 1.0.1
@@ -153,6 +122,25 @@ add_action( 'admin_init', function() {
 		flush_rewrite_rules();
 		delete_option( 'cbtj_flush_rewrite_rules' );
 	}
+} );
+
+/**
+ * Setup REST route for Export.
+ *
+ * @since 1.0.0
+ *
+ * @wp-hook 'rest_api_init'
+ */
+add_action( 'rest_api_init', function() {
+	register_rest_route(
+		'cbtj/v1',
+		'/(?P<id>\d+)',
+		[
+			'methods'             => \WP_REST_Server::READABLE,
+			'callback'            => __NAMESPACE__ . '\get_json_export',
+			'permission_callback' => '__return_true',
+		]
+	);
 } );
 
 /**
@@ -247,6 +235,26 @@ function get_export( $block ): array {
 		'innerBlocks' => $children
 	];
 }
+
+/**
+ * Setup REST route for Import.
+ *
+ * @since 1.0.1 Added `import` REST endpoint.
+ * @since 1.0.2 Serve is_user_permissible for permissions.
+ *
+ * @wp-hook 'rest_api_init'
+ */
+add_action( 'rest_api_init', function() {
+	register_rest_route(
+		'cbtj/v1',
+		'/import',
+		[
+			'methods'             => \WP_REST_Server::CREATABLE,
+			'callback'            => __NAMESPACE__ . '\get_json_import',
+			'permission_callback' => __NAMESPACE__ . '\is_user_permissible',
+		]
+	);
+} );
 
 /**
  * Get REST Response.

--- a/convert-blocks-to-json.php
+++ b/convert-blocks-to-json.php
@@ -158,15 +158,15 @@ add_action( 'admin_init', function() {
 /**
  * Get REST Response.
  *
- * This method grabs the REST Response needed
- * for generating the JSON.
+ * This method gets exportable JSON data
+ * for the blocks.
  *
  * @since 1.0.0
  *
- * @param \WP_REST_Request $request Request Object.
- * @return \WP_REST_Response
- *
  * @wp-hook 'rest_api_init'
+ *
+ * @param \WP_REST_Request $request Request Object.
+ * @return \WP_REST_Response|\WP_Error
  */
 function get_rest_response( $request ): \WP_REST_Response {
 	$post_id      = (int) $request->get_param( 'id' );
@@ -193,7 +193,7 @@ function get_rest_response( $request ): \WP_REST_Response {
 }
 
 /**
- * Get Blocks.
+ * Get Blocks Export.
  *
  * This method is responsible for getting WP
  * valid blocks.
@@ -256,10 +256,10 @@ function get_json( $block ): array {
  *
  * @since 1.0.1
  *
- * @param \WP_REST_Request $request Request Object.
- * @return \WP_REST_Response
- *
  * @wp-hook 'rest_api_init'
+ *
+ * @param \WP_REST_Request $request Request Object.
+ * @return \WP_REST_Response|\WP_Error
  */
 function get_json_import( $request ): \WP_REST_Response {
 	$args = $request->get_json_params();
@@ -268,7 +268,7 @@ function get_json_import( $request ): \WP_REST_Response {
 	$post_id   = (int) ( $args['id'] ?? '' );
 	$json_file = get_attached_file( $post_id );
 
-	//Bail out, if it does NOT exists.
+	// Bail out, if it does NOT exists.
 	if ( ! file_exists( $json_file ) ) {
 		return new \WP_Error(
 			'cbtj-bad-request',
@@ -283,7 +283,7 @@ function get_json_import( $request ): \WP_REST_Response {
 		);
 	}
 
-	//Bail out, if it is not JSON.
+	// Bail out, if it is not JSON.
 	if ( 'json' !== wp_check_filetype( $json_file )['ext'] ?? '' ) {
 		return new \WP_Error(
 			'cbtj-bad-request',
@@ -306,7 +306,7 @@ function get_json_import( $request ): \WP_REST_Response {
 }
 
 /**
- * Get JSON Content.
+ * Get Blocks Import.
  *
  * Loop through the JSON array of blocks
  * and render as string.
@@ -374,10 +374,10 @@ function get_content( $block ): array {
  *
  * @since 1.0.2
  *
+ * @wp-hook 'rest_api_init'
+ *
  * @param \WP_REST_Request $request Request Object.
  * @return bool|\WP_Error
- *
- * @wp-hook 'rest_api_init'
  */
 function is_user_permissible( $request ) {
 	$http_error = rest_authorization_required_code();

--- a/convert-blocks-to-json.php
+++ b/convert-blocks-to-json.php
@@ -310,7 +310,7 @@ function get_json_import( $request ) {
 	$json   = file_get_contents( $json_file );
 	$import = get_blocks_import( json_decode( $json, true ), $post_id );
 
-	return new \WP_REST_Response( $import );
+	return rest_ensure_response( $import );
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -93,7 +93,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 = 1.0.0 =
 * Convert & Export Blocks to JSON.
-* Custom Hooks - `cbtj_rest_response`.
+* Custom Hooks - `cbtj_rest_export`.
 * Provided support for Arabic, Chinese, Hebrew, Hindi, Russian, German, Italian, Croatian, Spanish & French languages.
 * Unit Tests coverage.
 * Tested up to WP 6.6.1.


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/convert-blocks-to-json/issues/2).

## Description / Background Context

We need to ensure that the response obtained after blocks' imports or exports are `REST` based. This PR implements this correctly.

## Testing Instructions

1. Pull PR to local.
2. Build repo correctly like so: `rm -rf node_modules && yarn install & yarn dev`
3. Open an article or post.
4. All previous functionality should work correctly without any regressions.