### PR TITLE
Release 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.0.7
+* Ensure `REST` response for blocks' imports & exports.
+* Update Hook names `cbtj_rest_response` to `cbtj_rest_export`.
+* Update function names.
+* Update README docs.
+* Tested up to WP 6.7.2.
+
 ## 1.0.6
 * Fix breaking/faulty dependency.
 * Fix linting issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 
 ## 1.0.0 (Initial Release)
 * Convert & Export Blocks to JSON.
-* Custom Hooks - `cbtj_rest_response`.
+* Custom Hooks - `cbtj_rest_export`.
 * Provided support for Arabic, Chinese, Hebrew, Hindi, Russian, German, Italian, Croatian, Spanish & French languages.
 * Unit Tests coverage.
 * Tested up to WP 6.6.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 
 ## 1.0.0 (Initial Release)
 * Convert & Export Blocks to JSON.
-* Custom Hooks - `cbtj_rest_export`.
+* Custom Hooks - `cbtj_rest_response`.
 * Provided support for Arabic, Chinese, Hebrew, Hindi, Russian, German, Italian, Croatian, Spanish & French languages.
 * Unit Tests coverage.
 * Tested up to WP 6.6.1.

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ https://github.com/user-attachments/assets/9dedf30f-9df0-4307-b634-cecef930a6e5
 
 ### Hooks
 
-#### `cbtj_rest_response`
+#### `cbtj_rest_export`
 
 This custom hook (filter) provides the ability to customise the REST response obtained:
 
 ```php
-add_filter( 'cbtj_rest_response', [ $this, 'custom_rest_response' ], 10, 2 );
+add_filter( 'cbtj_rest_export', [ $this, 'custom_rest_export' ], 10, 2 );
 
-public function custom_rest_response( $response, $post_id ): array {
+public function custom_rest_export( $response, $post_id ): array {
     $response['content'] = wp_parse_args(
         [
             'name'    => 'custom/post-meta-block',

--- a/convert-blocks-to-json.php
+++ b/convert-blocks-to-json.php
@@ -3,7 +3,7 @@
  * Plugin Name: Convert Blocks to JSON
  * Plugin URI:  https://github.com/badasswp/convert-blocks-to-json
  * Description: Convert your WP blocks to JSON.
- * Version:     1.0.6
+ * Version:     1.0.7
  * Author:      badasswp
  * Author URI:  https://github.com/badasswp
  * License:     GPL v2 or later

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-blocks-to-json",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Convert your WP blocks to JSON.",
   "author": "badasswp",
   "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -54,6 +54,13 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.0.7 =
+* Ensure `REST` response for blocks' imports & exports.
+* Update Hook names `cbtj_rest_response` to `cbtj_rest_export`.
+* Update function names.
+* Update README docs.
+* Tested up to WP 6.7.2.
+
 = 1.0.6 =
 * Fix breaking/faulty dependency.
 * Fix linting issues.

--- a/readme.txt
+++ b/readme.txt
@@ -8,7 +8,7 @@ Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Convert your WP blocks to JSON.
+Convert your WP blocks to JSON. Import & Export blocks across multiple WordPress websites easily & quickly. Generate JSON for Headless CMS websites.
 
 == Installation ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -100,7 +100,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 = 1.0.0 =
 * Convert & Export Blocks to JSON.
-* Custom Hooks - `cbtj_rest_export`.
+* Custom Hooks - `cbtj_rest_response`.
 * Provided support for Arabic, Chinese, Hebrew, Hindi, Russian, German, Italian, Croatian, Spanish & French languages.
 * Unit Tests coverage.
 * Tested up to WP 6.6.1.

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: badasswp
 Tags: convert, blocks, json, gutenberg, editor.
 Requires at least: 4.0
-Tested up to: 6.7.1
-Stable tag: 1.0.6
+Tested up to: 6.7.2
+Stable tag: 1.0.7
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -93,7 +93,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 = 1.0.0 =
 * Convert & Export Blocks to JSON.
-* Custom Hooks - `cbtj_rest_response`.
+* Custom Hooks - `cbtj_rest_export`.
 * Provided support for Arabic, Chinese, Hebrew, Hindi, Russian, German, Italian, Croatian, Spanish & French languages.
 * Unit Tests coverage.
 * Tested up to WP 6.6.1.


### PR DESCRIPTION
This release contains the following fixes:

- Ensure `REST` response for blocks' imports & exports.
- Update Hook names `cbtj_rest_response` to `cbtj_rest_export`.
- Update function names.
- Update README docs.
- Tested up to WP 6.7.2.