### PR TITLE
Chore: Enforce WP linting across plugin

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -1,5 +1,7 @@
 .babelrc
 .editorconfig
+.eslintignore
+.eslintrc.js
 .gitignore
 .github
 CHANGELOG.md

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,4 +10,4 @@ trim_trailing_whitespace = true
 
 [*.{js,jsx,ts,tsx,json,yml,yaml,babelrc,md}]
 indent_size = 2
-indent_style = space
+indent_style = tab

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules/
+vendor/
+build/
+dist/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+	root: true,
+	extends: [ 'plugin:@wordpress/recommended' ],
+	rules: {
+		'import/no-extraneous-dependencies': [ 'error' ],
+	},
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
       run: |
         yarn install
 
+    - name: Check Linting
+      run: |
+        yarn lint:js
+
     - name: Run Test Suites
       run: |
         yarn test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.8
+* Enforce WP style linting across plugin.
+* Tested up to WP 6.7.2.
+
 ## 1.0.7
 * Ensure `REST` response for blocks' imports & exports.
 * Update Hook names `cbtj_rest_response` to `cbtj_rest_export`.

--- a/convert-blocks-to-json.php
+++ b/convert-blocks-to-json.php
@@ -3,7 +3,7 @@
  * Plugin Name: Convert Blocks to JSON
  * Plugin URI:  https://github.com/badasswp/convert-blocks-to-json
  * Description: Convert your WP blocks to JSON.
- * Version:     1.0.7
+ * Version:     1.0.8
  * Author:      badasswp
  * Author URI:  https://github.com/badasswp
  * License:     GPL v2 or later

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,16 +1,14 @@
-const baseConfig = require('@wordpress/scripts/config/jest-unit.config.js');
+const baseConfig = require( '@wordpress/scripts/config/jest-unit.config.js' );
 
 module.exports = {
-  ...baseConfig,
-  preset: 'ts-jest',
-  testEnvironment: 'jsdom',
-  setupFilesAfterEnv: [
-    './jest.setup.js'
-  ],
-  transform: {
-    '^.+\\.jsx?$': 'babel-jest',
-  },
-  moduleNameMapper: {
-    'uuid': require.resolve('uuid'),
-  },
+	...baseConfig,
+	preset: 'ts-jest',
+	testEnvironment: 'jsdom',
+	setupFilesAfterEnv: [ './jest.setup.js' ],
+	transform: {
+		'^.+\\.jsx?$': 'babel-jest',
+	},
+	moduleNameMapper: {
+		uuid: require.resolve( 'uuid' ),
+	},
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convert-blocks-to-json",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Convert your WP blocks to JSON.",
   "author": "badasswp",
   "license": "GPL-2.0-or-later",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "dev": "webpack --watch",
     "build": "webpack",
     "test": "npm-run-all --parallel test:*",
-    "test:js": "jest --passWithNoTests"
+    "test:js": "jest --passWithNoTests",
+    "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
+    "format": "eslint . --ext .js,.jsx,.ts,.tsx --fix"
   },
   "devDependencies": {
     "@babel/core": "^7.22.11",
@@ -21,7 +24,6 @@
     "@testing-library/jest-dom": "5.17",
     "@testing-library/react": "15.0.6",
     "@types/jest": "^29.5.4",
-    "@wordpress/eslint-plugin": "^15.0.0",
     "@wordpress/scripts": "^26.9.0",
     "css-loader": "^6.8.1",
     "file-loader": "^6.2.0",
@@ -51,7 +53,8 @@
     "@wordpress/hooks": "^3.38.0",
     "@wordpress/i18n": "^4.38.0",
     "@wordpress/keyboard-shortcuts": "^4.15.0",
-    "@wordpress/plugins": "^6.10.0"
+    "@wordpress/plugins": "^6.10.0",
+    "react": "^18.3.1"
   },
   "keywords": [
     "wordpress",

--- a/readme.txt
+++ b/readme.txt
@@ -54,6 +54,10 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.0.8 =
+* Enforce WP style linting across plugin.
+* Tested up to WP 6.7.2.
+
 = 1.0.7 =
 * Ensure `REST` response for blocks' imports & exports.
 * Update Hook names `cbtj_rest_response` to `cbtj_rest_export`.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: badasswp
 Tags: convert, blocks, json, gutenberg, editor.
 Requires at least: 4.0
 Tested up to: 6.7.2
-Stable tag: 1.0.7
+Stable tag: 1.0.8
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/components/ExportJSON.tsx
+++ b/src/components/ExportJSON.tsx
@@ -11,52 +11,46 @@ import { getBlocks } from '../utils';
  *
  * @since 1.0.0
  *
- * @returns {JSX.Element}
+ * @return {JSX.Element} Export JSON.
  */
-const ExportJSON = () => {
-  /**
-   * Generates the JSON export file
-   * and nothing more.
-   *
-   * @since 1.0.1
-   *
-   * @returns {Promise<void>}
-   */
-  const handleExport = async(): Promise<void> => {
-    const jsonBlocks = await getBlocks();
-    const jsonString = JSON.stringify( jsonBlocks, null, 2 );
-    const jsonURL    = URL.createObjectURL(
-      new Blob(
-        [jsonString],
-        { type: 'application/json' }
-      )
-    );
+const ExportJSON = (): JSX.Element => {
+	/**
+	 * Generates the JSON export file
+	 * and nothing more.
+	 *
+	 * @since 1.0.1
+	 *
+	 * @return {Promise<void>}
+	 */
+	const handleExport = async (): Promise< void > => {
+		const jsonBlocks = await getBlocks();
+		const jsonString = JSON.stringify( jsonBlocks, null, 2 );
+		const jsonURL = URL.createObjectURL(
+			new Blob( [ jsonString ], { type: 'application/json' } )
+		);
 
-    // Define Anchor.
-    const a    = document.createElement( 'a' );
-    a.href     = jsonURL;
-    a.download = `convert-blocks-to-json-${Date.now()}.json`;
+		// Define Anchor.
+		const a = document.createElement( 'a' );
+		a.href = jsonURL;
+		a.download = `convert-blocks-to-json-${ Date.now() }.json`;
 
-    // Fire Anchor.
-    document.body.appendChild( a );
-    a.click();
+		// Fire Anchor.
+		document.body.appendChild( a );
+		a.click();
 
-    // Clear Anchor.
-    URL.revokeObjectURL( jsonURL );
-    document.body.removeChild( a );
-  }
+		// Clear Anchor.
+		URL.revokeObjectURL( jsonURL );
+		document.body.removeChild( a );
+	};
 
-  return (
-    <>
-      <p>{ __( 'Export Blocks to JSON', 'convert-blocks-to-json' ) }</p>
-      <Button
-        variant="primary"
-        onClick={ handleExport }
-      >
-        { __( 'Export Blocks', 'convert-blocks-to-json' ) }
-      </Button>
-    </>
-  )
-}
+	return (
+		<>
+			<p>{ __( 'Export Blocks to JSON', 'convert-blocks-to-json' ) }</p>
+			<Button variant="primary" onClick={ handleExport }>
+				{ __( 'Export Blocks', 'convert-blocks-to-json' ) }
+			</Button>
+		</>
+	);
+};
 
 export default ExportJSON;

--- a/src/components/ImportJSON.tsx
+++ b/src/components/ImportJSON.tsx
@@ -14,37 +14,62 @@ import { getModalParams, getImport } from '../utils';
  * @since 1.0.0
  * @since 1.0.1 Implement handleModal callback.
  *
- * @returns {JSX.Element}
+ * @return {JSX.Element} Import JSON.
  */
 const ImportJSON = (): JSX.Element => {
-  const handleModal = () => {
-    const wpMediaModal = wp.media( getModalParams() );
-    wpMediaModal.on( 'select', () => handleImport( wpMediaModal ) ).open();
-  }
+	/**
+	 * Handles the Modal.
+	 *
+	 * This function is responsible for handling the
+	 * WP Media Modal and its selection.
+	 *
+	 * @since 1.0.1
+	 *
+	 * @return {void}
+	 */
+	const handleModal = () => {
+		const wpMediaModal = wp.media( getModalParams() );
+		wpMediaModal.on( 'select', () => handleImport( wpMediaModal ) ).open();
+	};
 
-  const handleImport = async ( wpMediaModal ) => {
-    const attachment = wpMediaModal.state().get('selection').first().toJSON();
-    const jsonImport = await getImport( attachment ) as any[];
+	/**
+	 * Handles the Import.
+	 *
+	 * This function is responsible for handling the
+	 * JSON import and its insertion.
+	 *
+	 * @since 1.0.1
+	 *
+	 * @param {Object} wpMediaModal
+	 *
+	 * @return {Promise<void>}
+	 */
+	const handleImport = async ( wpMediaModal ) => {
+		const attachment = wpMediaModal
+			.state()
+			.get( 'selection' )
+			.first()
+			.toJSON();
+		const jsonImport = ( await getImport( attachment ) ) as any[];
 
-    jsonImport.forEach( ( { name, attributes, innerBlocks } ) => {
-      attributes = JSON.parse( attributes );
-      ( dispatch('core/block-editor') as { insertBlocks: any } ).insertBlocks(
-        createBlock( name, { ...attributes }, innerBlocks )
-      );
-    } );
-  };
+		jsonImport.forEach( ( { name, attributes, innerBlocks } ) => {
+			attributes = JSON.parse( attributes );
+			(
+				dispatch( 'core/block-editor' ) as { insertBlocks: any }
+			 ).insertBlocks(
+				createBlock( name, { ...attributes }, innerBlocks )
+			);
+		} );
+	};
 
-  return (
-    <>
-      <p>{ __( 'Import Blocks by JSON', 'convert-blocks-to-json' ) }</p>
-      <Button
-        variant="primary"
-        onClick={ handleModal }
-      >
-        { __( 'Import Blocks', 'convert-blocks-to-json' ) }
-      </Button>
-    </>
-  )
-}
+	return (
+		<>
+			<p>{ __( 'Import Blocks by JSON', 'convert-blocks-to-json' ) }</p>
+			<Button variant="primary" onClick={ handleModal }>
+				{ __( 'Import Blocks', 'convert-blocks-to-json' ) }
+			</Button>
+		</>
+	);
+};
 
 export default ImportJSON;

--- a/src/components/ViewJSON.tsx
+++ b/src/components/ViewJSON.tsx
@@ -10,24 +10,25 @@ import { Button } from '@wordpress/components';
  *
  * @since 1.0.0
  *
- * @returns {JSX.Element}
+ * @return {JSX.Element} View JSON.
  */
-const ViewJSON = () => {
-  const postID = select('core/editor').getCurrentPostId();
+const ViewJSON = (): JSX.Element => {
+	const postID = select( 'core/editor' ).getCurrentPostId();
 
-  return (
-    <>
-      <p>{ __( 'View JSON', 'convert-blocks-to-json' ) }</p>
-      <a href={`${cbtj.url}/wp-json/cbtj/v1/${postID}`} target="_blank">
-        <Button
-          variant="primary"
-          onClick={ () => { } }
-        >
-          { __( 'View JSON', 'convert-blocks-to-json' ) }
-        </Button>
-      </a>
-    </>
-  )
-}
+	return (
+		<>
+			<p>{ __( 'View JSON', 'convert-blocks-to-json' ) }</p>
+			<a
+				href={ `${ cbtj.url }/wp-json/cbtj/v1/${ postID }` }
+				target="_blank"
+				rel="noreferrer"
+			>
+				<Button variant="primary" onClick={ () => {} }>
+					{ __( 'View JSON', 'convert-blocks-to-json' ) }
+				</Button>
+			</a>
+		</>
+	);
+};
 
 export default ViewJSON;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,43 +18,42 @@ import './styles/app.scss';
  *
  * @since 1.0.0
  *
- * @returns {JSX.Element}
+ * @return {JSX.Element} Convert Blocks To JSON.
  */
-const ConvertBlocksToJSON = () => {
-  return (
-    <Fragment>
-      <PluginSidebarMoreMenuItem
-        target="cbtj-sidebar"
-        icon="editor-code"
-      >
-        { __( 'Convert Blocks to JSON', 'convert-blocks-to-json' ) }
-      </PluginSidebarMoreMenuItem>
-      <PluginSidebar
-        name="cbtj-sidebar"
-        title={ __( 'Convert Blocks to JSON', 'convert-blocks-to-json' ) }
-        icon="editor-code"
-      >
-        <PanelBody>
-          <div id="cbtj">
-            <ul>
-              <li>
-                <ViewJSON />
-              </li>
-              <li>
-                <ImportJSON />
-              </li>
-              <li>
-                <ExportJSON />
-              </li>
-            </ul>
-          </div>
-        </PanelBody>
-      </PluginSidebar>
-    </Fragment>
-  );
+const ConvertBlocksToJSON = (): JSX.Element => {
+	return (
+		<Fragment>
+			<PluginSidebarMoreMenuItem target="cbtj-sidebar" icon="editor-code">
+				{ __( 'Convert Blocks to JSON', 'convert-blocks-to-json' ) }
+			</PluginSidebarMoreMenuItem>
+			<PluginSidebar
+				name="cbtj-sidebar"
+				title={ __(
+					'Convert Blocks to JSON',
+					'convert-blocks-to-json'
+				) }
+				icon="editor-code"
+			>
+				<PanelBody>
+					<div id="cbtj">
+						<ul>
+							<li>
+								<ViewJSON />
+							</li>
+							<li>
+								<ImportJSON />
+							</li>
+							<li>
+								<ExportJSON />
+							</li>
+						</ul>
+					</div>
+				</PanelBody>
+			</PluginSidebar>
+		</Fragment>
+	);
 };
 
 registerPlugin( 'convert-blocks-to-json', {
-  render: ConvertBlocksToJSON,
+	render: ConvertBlocksToJSON,
 } );
-

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -11,17 +11,15 @@ import apiFetch from '@wordpress/api-fetch';
  *
  * @since 1.0.0
  *
- * @returns {Promise<any[]>}
+ * @return {Promise<any[]>} Blocks.
  */
-export const getBlocks = (): Promise<any[]> => {
-  const postID = select( 'core/editor' ).getCurrentPostId();
+export const getBlocks = (): Promise< any[] > => {
+	const postID = select( 'core/editor' ).getCurrentPostId();
 
-  return apiFetch(
-    {
-      path: `/cbtj/v1/${postID}`
-    }
-  );
-}
+	return apiFetch( {
+		path: `/cbtj/v1/${ postID }`,
+	} );
+};
 
 /**
  * Get Import.
@@ -29,21 +27,20 @@ export const getBlocks = (): Promise<any[]> => {
  * This function reaches out to the import endpoint
  * and gets the list of JSON blocks.
  *
+ * @param  attachment
  * @since 1.0.1
  *
- * @returns {Promise<any[]>}
+ * @return {Promise<any[]>} Import.
  */
-export const getImport = ( attachment ): Promise<any[]> => {
-  return apiFetch(
-    {
-      path: '/cbtj/v1/import',
-      method: 'POST',
-      data: {
-        ...attachment
-      },
-    }
-  );
-}
+export const getImport = ( attachment ): Promise< any[] > => {
+	return apiFetch( {
+		path: '/cbtj/v1/import',
+		method: 'POST',
+		data: {
+			...attachment,
+		},
+	} );
+};
 
 /**
  * Get Modal Params.
@@ -54,14 +51,14 @@ export const getImport = ( attachment ): Promise<any[]> => {
  *
  * @since 1.0.1
  *
- * @returns {Object} Modal Params.
+ * @return {Object} Modal Params.
  */
-export const getModalParams = () => {
-  return {
-    title: __( 'Select JSON File', 'convert-blocks-to-json' ),
-    button: {
-      text: __( 'Use JSON', 'convert-blocks-to-json' )
-    },
-    multiple: false
-  };
-}
+export const getModalParams = (): object => {
+	return {
+		title: __( 'Select JSON File', 'convert-blocks-to-json' ),
+		button: {
+			text: __( 'Use JSON', 'convert-blocks-to-json' ),
+		},
+		multiple: false,
+	};
+};

--- a/tests/Args.test.tsx
+++ b/tests/Args.test.tsx
@@ -3,118 +3,108 @@ import '@testing-library/jest-dom';
 import { getBlocks, getModalParams, getImport } from '../src/utils';
 
 jest.mock( '@wordpress/data', () => ( {
-  select: jest.fn( ( arg ) => {
-    if ( 'core/editor' === arg ) {
-      return {
-        getCurrentPostId: jest.fn( () => 7 ),
-      };
-    }
-    return {};
-  } ),
+	select: jest.fn( ( arg ) => {
+		if ( 'core/editor' === arg ) {
+			return {
+				getCurrentPostId: jest.fn( () => 7 ),
+			};
+		}
+		return {};
+	} ),
 } ) );
 
 jest.mock( '@wordpress/api-fetch', () => {
-  function apiFetchMock( options ) {
-    const { path, method } = options;
+	function apiFetchMock( options ) {
+		const { path, method } = options;
 
-    if ( '/cbtj/v1/7' === path ) {
-      return Promise.resolve(
-        [
-          {
-            blockName: 'core/paragraph',
-            innerHTML: '<p>Hello World</p>',
-            innerBlocks: [],
-          },
-          {
-            blockName: 'core/heading',
-            innerHTML: '<h1>Hello World</h1>',
-            innerBlocks: [],
-          }
-        ]
-      );
-    }
+		if ( '/cbtj/v1/7' === path ) {
+			return Promise.resolve( [
+				{
+					blockName: 'core/paragraph',
+					innerHTML: '<p>Hello World</p>',
+					innerBlocks: [],
+				},
+				{
+					blockName: 'core/heading',
+					innerHTML: '<h1>Hello World</h1>',
+					innerBlocks: [],
+				},
+			] );
+		}
 
-    if ( '/cbtj/v1/import' === path && 'POST' === method ) {
-      return Promise.resolve(
-        [
-          {
-            name: 'core/paragraph',
-            attributes: {
-              content: '<p>Hello World</p>'
-            },
-            innerBlocks: [],
-          },
-          {
-            name: 'core/heading',
-            attributes: {
-              content: '<h1>Hello World</h1>'
-            },
-            innerBlocks: [],
-          },
-        ]
-      );
-    }
+		if ( '/cbtj/v1/import' === path && 'POST' === method ) {
+			return Promise.resolve( [
+				{
+					name: 'core/paragraph',
+					attributes: {
+						content: '<p>Hello World</p>',
+					},
+					innerBlocks: [],
+				},
+				{
+					name: 'core/heading',
+					attributes: {
+						content: '<h1>Hello World</h1>',
+					},
+					innerBlocks: [],
+				},
+			] );
+		}
 
-    return Promise.reject( new Error( 'Unknown path' ) );
-  };
+		return Promise.reject( new Error( 'Unknown path' ) );
+	}
 
-  apiFetchMock.use = jest.fn();
-  apiFetchMock.createNonceMiddleware = jest.fn();
+	apiFetchMock.use = jest.fn();
+	apiFetchMock.createNonceMiddleware = jest.fn();
 
-  return apiFetchMock;
+	return apiFetchMock;
 } );
 
 describe( 'Utilities', () => {
-  it( 'gets the Blocks', async () => {
-    const blocks = await getBlocks();
-    expect( blocks ).toEqual(
-      [
-        {
-          blockName: 'core/paragraph',
-          innerHTML: '<p>Hello World</p>',
-          innerBlocks: [],
-        },
-        {
-          blockName: 'core/heading',
-          innerHTML: '<h1>Hello World</h1>',
-          innerBlocks: [],
-        }
-      ]
-    );
-  } );
+	it( 'gets the Blocks', async () => {
+		const blocks = await getBlocks();
+		expect( blocks ).toEqual( [
+			{
+				blockName: 'core/paragraph',
+				innerHTML: '<p>Hello World</p>',
+				innerBlocks: [],
+			},
+			{
+				blockName: 'core/heading',
+				innerHTML: '<h1>Hello World</h1>',
+				innerBlocks: [],
+			},
+		] );
+	} );
 
-  it( 'gets the Modal Params', () => {
-    const params = getModalParams();
-    expect( params ).toEqual(
-      {
-        title: 'Select JSON File',
-        button: {
-          text: 'Use JSON',
-        },
-        multiple: false
-      }
-    );
-  } );
+	it( 'gets the Modal Params', () => {
+		const params = getModalParams();
+		expect( params ).toEqual( {
+			title: 'Select JSON File',
+			button: {
+				text: 'Use JSON',
+			},
+			multiple: false,
+		} );
+	} );
 
-  it( 'gets the Import Blocks', async () => {
-    const importBlocks = await getImport( {} );
-    expect( importBlocks ).toEqual(
-      [
-        {
-          name: 'core/paragraph',
-          attributes: {
-            content: '<p>Hello World</p>'
-          },
-          innerBlocks: [],
-        },
-        {
-          name: 'core/heading',
-          attributes: {
-            content: '<h1>Hello World</h1>'
-          },
-          innerBlocks: [],
-        },
-      ]
-    );
-  } );
+	it( 'gets the Import Blocks', async () => {
+		const importBlocks = await getImport( {} );
+		expect( importBlocks ).toEqual( [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: '<p>Hello World</p>',
+				},
+				innerBlocks: [],
+			},
+			{
+				name: 'core/heading',
+				attributes: {
+					content: '<h1>Hello World</h1>',
+				},
+				innerBlocks: [],
+			},
+		] );
+	} );
 } );

--- a/tests/ExportJSON.test.tsx
+++ b/tests/ExportJSON.test.tsx
@@ -5,35 +5,37 @@ import '@testing-library/jest-dom';
 import ExportJSON from '../src/components/ExportJSON';
 
 jest.mock( '@wordpress/data', () => ( {
-  select: jest.fn( ( storeName ) => {
-    if ( storeName === 'core/editor' ) {
-      return {
-        getCurrentPostId: jest.fn( () => 1 ),
-      };
-    }
-    return {};
-  } ),
+	select: jest.fn( ( storeName ) => {
+		if ( storeName === 'core/editor' ) {
+			return {
+				getCurrentPostId: jest.fn( () => 1 ),
+			};
+		}
+		return {};
+	} ),
 } ) );
 
 jest.mock( '@wordpress/i18n', () => ( {
-  __: jest.fn( ( text ) => text ),
+	__: jest.fn( ( text ) => text ),
 } ) );
 
 jest.mock( '@wordpress/components', () => ( {
-  Button: jest.fn( ( { children } ) => {
-    return (
-      <button type="button" className="components-button is-primary">{children}</button>
-    )
-  } ),
+	Button: jest.fn( ( { children } ) => {
+		return (
+			<button type="button" className="components-button is-primary">
+				{ children }
+			</button>
+		);
+	} ),
 } ) );
 
 describe( 'ExportJSON', () => {
-  it( 'renders the component with correct text', () => {
-    const { container } = render( <ExportJSON /> );
+	it( 'renders the component with correct text', () => {
+		const { container } = render( <ExportJSON /> );
 
-    // Expect Component to look like so:
-    expect( container.innerHTML ).toBe(
-      `<p>Export Blocks to JSON</p><button type="button" class="components-button is-primary">Export Blocks</button>`
-    );
-  } );
+		// Expect Component to look like so:
+		expect( container.innerHTML ).toBe(
+			`<p>Export Blocks to JSON</p><button type="button" class="components-button is-primary">Export Blocks</button>`
+		);
+	} );
 } );

--- a/tests/ViewJSON.test.tsx
+++ b/tests/ViewJSON.test.tsx
@@ -47,7 +47,7 @@ describe( 'ViewJSON', () => {
 
 		// Expect Component to look like so:
 		expect( container.innerHTML ).toBe(
-			`<p>View JSON</p><a href="https://example.com/wp-json/cbtj/v1/1" target="_blank"><button type="button" class="components-button is-primary">View JSON</button></a>`
+			`<p>View JSON</p><a href="https://example.com/wp-json/cbtj/v1/1" target="_blank" rel="noreferrer"><button type="button" class="components-button is-primary">View JSON</button></a>`
 		);
 	} );
 } );

--- a/tests/ViewJSON.test.tsx
+++ b/tests/ViewJSON.test.tsx
@@ -5,44 +5,49 @@ import '@testing-library/jest-dom';
 import ViewJSON from '../src/components/ViewJSON';
 
 jest.mock( '@wordpress/data', () => ( {
-  select: jest.fn( ( storeName ) => {
-    if ( storeName === 'core/editor' ) {
-      return {
-        getCurrentPostId: jest.fn( () => 1 ),
-      };
-    }
-    return {};
-  } ),
+	select: jest.fn( ( storeName ) => {
+		if ( storeName === 'core/editor' ) {
+			return {
+				getCurrentPostId: jest.fn( () => 1 ),
+			};
+		}
+		return {};
+	} ),
 } ) );
 
 jest.mock( '@wordpress/i18n', () => ( {
-  __: jest.fn( ( text ) => text ),
+	__: jest.fn( ( text ) => text ),
 } ) );
 
 jest.mock( '@wordpress/components', () => ( {
-  Button: jest.fn( ( { children } ) => {
-    return (
-      <button type="button" className="components-button is-primary">{children}</button>
-    )
-  } ),
+	Button: jest.fn( ( { children } ) => {
+		return (
+			<button type="button" className="components-button is-primary">
+				{ children }
+			</button>
+		);
+	} ),
 } ) );
 
 describe( 'ViewJSON', () => {
-  beforeAll( () => {
-    global.cbtj = { url: 'https://example.com' };
-  } );
+	beforeAll( () => {
+		global.cbtj = { url: 'https://example.com' };
+	} );
 
-  it( 'renders the component with correct text and link', () => {
-    const { container } = render( <ViewJSON /> );
+	it( 'renders the component with correct text and link', () => {
+		const { container } = render( <ViewJSON /> );
 
-    // Expect Correct link is generated:
-    const link = screen.getByRole( 'link' );
-    expect( link ).toHaveAttribute( 'target', '_blank' );
-    expect( link ).toHaveAttribute( 'href', 'https://example.com/wp-json/cbtj/v1/1' );
+		// Expect Correct link is generated:
+		const link = screen.getByRole( 'link' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link ).toHaveAttribute(
+			'href',
+			'https://example.com/wp-json/cbtj/v1/1'
+		);
 
-    // Expect Component to look like so:
-    expect( container.innerHTML ).toBe(
-      `<p>View JSON</p><a href="https://example.com/wp-json/cbtj/v1/1" target="_blank"><button type="button" class="components-button is-primary">View JSON</button></a>`
-    );
-  } );
+		// Expect Component to look like so:
+		expect( container.innerHTML ).toBe(
+			`<p>View JSON</p><a href="https://example.com/wp-json/cbtj/v1/1" target="_blank"><button type="button" class="components-button is-primary">View JSON</button></a>`
+		);
+	} );
 } );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,64 +1,68 @@
-const path = require('path');
-const defaultConfig = require('@wordpress/scripts/config/webpack.config');
+const path = require( 'path' );
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 
 module.exports = {
-  ...defaultConfig,
+	...defaultConfig,
 
-  entry: {
-    app: './src/index.tsx',
-  },
+	entry: {
+		app: './src/index.tsx',
+	},
 
-  output: {
-    path: path.resolve(__dirname, 'dist'),
-    filename: '[name].js',
-  },
+	output: {
+		path: path.resolve( __dirname, 'dist' ),
+		filename: '[name].js',
+	},
 
-  resolve: {
-    extensions: ['.tsx', '.ts', '.js'],
-  },
+	resolve: {
+		extensions: [ '.tsx', '.ts', '.js' ],
+	},
 
-  module: {
-    rules: [
-      {
-        test: /\.ts(x)?$/,
-        exclude: /(node_modules|bower_components)/,
-        use: {
-          loader: 'ts-loader',
-          options: {
-            configFile: 'tsconfig.json',
-            transpileOnly: true
-          }
-        },
-      },
-      {
-        test: /\.js$/,
-        exclude: /(node_modules|bower_components)/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
-          },
-        },
-      },
-      {
-        test: /\.(png|jpg|jpeg|gif|svg)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              name: '[name].[ext]',
-              outputPath: 'images/',
-            },
-          },
-        ],
-      },
-      {
-        test: /\.scss$/,
-        use: ['style-loader', 'css-loader', 'sass-loader'],
-      },
-    ],
-  },
+	module: {
+		rules: [
+			{
+				test: /\.ts(x)?$/,
+				exclude: /(node_modules|bower_components)/,
+				use: {
+					loader: 'ts-loader',
+					options: {
+						configFile: 'tsconfig.json',
+						transpileOnly: true,
+					},
+				},
+			},
+			{
+				test: /\.js$/,
+				exclude: /(node_modules|bower_components)/,
+				use: {
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							'@babel/preset-env',
+							'@babel/preset-react',
+							'@babel/preset-typescript',
+						],
+					},
+				},
+			},
+			{
+				test: /\.(png|jpg|jpeg|gif|svg)$/,
+				use: [
+					{
+						loader: 'file-loader',
+						options: {
+							name: '[name].[ext]',
+							outputPath: 'images/',
+						},
+					},
+				],
+			},
+			{
+				test: /\.scss$/,
+				use: [ 'style-loader', 'css-loader', 'sass-loader' ],
+			},
+		],
+	},
 
-  devtool: 'source-map',
-  mode: 'production'
+	devtool: 'source-map',
+	mode: 'production',
 };


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/convert-blocks-to-json/issues/5).

## Description / Background Context

Similar to [43](https://github.com/badasswp/search-and-replace/pull/44), there is a need to enforce WP style linting across the codebase to ensure consistency among PRs. Once done, Contributors should be able to lint and perform fixes easily like so:

```js
yarn lint:fix
```

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn dev`.
3. Now run `yarn lint:fix` to correctly lint your JS files.
4. All other features should work correctly as before.