### PR TITLE
Chore: Add local dev env setup for WP

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -4,6 +4,7 @@
 .eslintrc.js
 .gitignore
 .github
+.wp-env.json
 CHANGELOG.md
 jest.config.js
 jest.setup.js
@@ -13,3 +14,4 @@ webpack.config.js
 assets
 src
 tests
+bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,10 @@ jobs:
         git config user.name "${USER_NAME}"
         git checkout -b master-built
 
-    - name: Set up Node.js 18.x
+    - name: Set up Node.js 20.x
       uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 20.x
 
     - name: Build Dist folder
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,19 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Node.js 18.x
+    - name: Set up Node.js 20.x
       uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 20.x
 
     - name: Install NPM
       run: |
         yarn install
 
-    - name: Check Linting
+    - name: Check JS Linting
       run: |
         yarn lint:js
 
-    - name: Run Test Suites
+    - name: Run JS Unit Tests
       run: |
-        yarn test
+        yarn test:js

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,16 @@
+{
+	"plugins": [
+		"."
+	],
+	"phpVersion": "8.2",
+	"port": 5478,
+	"testsPort": 5479,
+	"config": {
+		"ALLOW_UNFILTERED_UPLOADS": true,
+		"WP_SITEURL": "http://cbtj.localhost",
+		"WP_HOME": "http://cbtj.localhost"
+	},
+	"lifecycleScripts": {
+		"afterStart": "./bin/setup.sh"
+	}
+}

--- a/README.md
+++ b/README.md
@@ -71,11 +71,32 @@ public function custom_rest_import( $import, $post_id ): array {
 - import _`{mixed[]}`_ REST Import. By default this is an array of Blocks.
 - post_id _`{int}`_ Post ID.
 
-## Development
+---
 
-### Setup
+## Contribute
 
-- Clone the repository.
-- Make sure you have [Node](https://nodejs.org) installed on your computer.
-- Run `yarn install && yarn build` to build JS dependencies.
-- For local development, you can use [Docker](https://docs.docker.com/install/) or [Local by Flywheel](https://localwp.com/).
+Contributions are __welcome__ and will be fully __credited__. To contribute, please fork this repo and raise a PR (Pull Request) against the `master` branch.
+
+### Pre-requisites
+
+You should have the following tools before proceeding to the next steps:
+
+- Composer
+- Yarn
+- Docker
+
+To enable you start development, please run:
+
+```bash
+yarn start
+```
+
+This should spin up a local WP env instance for you to work with at:
+
+```bash
+http://cbtj.localhost:5478
+```
+
+You should now have a functioning local WP env to work with. To login to the `wp-admin` backend, please username as `admin` & password as `password`.
+
+__Awesome!__ - Thanks for being interested in contributing your time and code to this project!

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+wp-env run cli wp theme activate twentytwentythree
+wp-env run cli wp rewrite structure /%postname%

--- a/package.json
+++ b/package.json
@@ -5,16 +5,19 @@
   "author": "badasswp",
   "license": "GPL-2.0-or-later",
   "homepage": "https://github.com/badasswp/convert-blocks-to-json#readme",
-  "scripts": {
-    "start": "npm install && composer install",
-    "dev": "webpack --watch",
-    "build": "webpack",
-    "test": "npm-run-all --parallel test:*",
-    "test:js": "jest --passWithNoTests",
-    "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
-    "format": "eslint . --ext .js,.jsx,.ts,.tsx --fix"
-  },
+	"scripts": {
+		"start": "yarn install && yarn build && yarn wp-env start",
+		"stop": "yarn wp-env stop",
+		"watch": "webpack --watch",
+		"build": "webpack",
+		"test": "npm-run-all --parallel test:*",
+		"test:js": "jest --passWithNoTests",
+		"lint:js": "eslint . --ext .js,.jsx,.ts,.tsx",
+		"lint:js:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
+		"ci": "yarn test:js && yarn lint:js",
+		"wp-env": "wp-env",
+		"bash": "wp-env run cli bash"
+	},
   "devDependencies": {
     "@babel/core": "^7.22.11",
     "@babel/eslint-parser": "^7.22.10",
@@ -24,6 +27,7 @@
     "@testing-library/jest-dom": "5.17",
     "@testing-library/react": "15.0.6",
     "@types/jest": "^29.5.4",
+    "@wordpress/env": "^10.17.0",
     "@wordpress/scripts": "^26.9.0",
     "css-loader": "^6.8.1",
     "file-loader": "^6.2.0",


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/convert-blocks-to-json/issues/8).

## Description / Background Context

At the moment, contributors have to use their own methods of setting up this repo. We need to provide a consistent way for users to spin up this project's repo and contribute quickly perhaps using WP's `wp-env` so that users can now spin up their local instance by running:

```bash
yarn wp-env start
```

This PR implements this correctly.

## Testing Instructions

1. Pull PR to local.
2. Build correctly by running `rm -rf node_modules && yarn start`.
3. The repo should now build and boot up the `wp-env` instance ready for the user.
4. User should be able to access the site at: `http://cbtj.localhost:5478`