### PR TITLE
Refactor: Replace `get_400_response` with `get_error_response`

### DIFF
--- a/inc/Abstracts/Route.php
+++ b/inc/Abstracts/Route.php
@@ -91,25 +91,26 @@ abstract class Route implements Router {
 	}
 
 	/**
-	 * Get 400 Response.
+	 * Get Error Response.
 	 *
-	 * This method returns a 400 response for Bad
+	 * This method returns an error response for Bad
 	 * requests submitted.
 	 *
 	 * @since 1.1.0
 	 *
 	 * @param string $message Error Msg.
+	 * @param int    $code    Error Status code.
 	 * @return \WP_Error
 	 */
-	public function get_400_response( $message ): WP_Error {
+	public function get_error_response( $message, $code = 400 ): WP_Error {
 		return new WP_Error(
 			'cbtj-bad-request',
 			sprintf(
-				'Fatal Error: Bad Request, %s',
+				'Fatal Error: %s',
 				$message
 			),
 			[
-				'status' => 400,
+				'status' => $code,
 			]
 		);
 	}

--- a/inc/Routes/Import.php
+++ b/inc/Routes/Import.php
@@ -58,7 +58,7 @@ class Import extends Route implements Router {
 
 		// Bail out, if it does NOT exists.
 		if ( ! file_exists( $json_file ) ) {
-			return $this->get_400_response(
+			return $this->get_error_response(
 				sprintf(
 					'File does not exists for ID: %s',
 					$post_id
@@ -68,7 +68,7 @@ class Import extends Route implements Router {
 
 		// Bail out, if it is not JSON.
 		if ( 'json' !== wp_check_filetype( $json_file )['ext'] ?? '' ) {
-			return $this->get_400_response(
+			return $this->get_error_response(
 				sprintf(
 					'Fatal Error: Wrong file type: %s',
 					$args['filename'] ?? ''

--- a/tests/php/Abstracts/RouteTest.php
+++ b/tests/php/Abstracts/RouteTest.php
@@ -15,7 +15,7 @@ use ConvertBlocksToJSON\Abstracts\Route;
  * @covers \ConvertBlocksToJSON\Abstracts\Route::get_permission_callback
  * @covers \ConvertBlocksToJSON\Abstracts\Route::get_rest_namespace
  * @covers \ConvertBlocksToJSON\Abstracts\Route::register_route
- * @covers \ConvertBlocksToJSON\Abstracts\Route::get_400_response
+ * @covers \ConvertBlocksToJSON\Abstracts\Route::get_error_response
  * @covers \ConvertBlocksToJSON\Abstracts\Route::is_user_permissible
  */
 class RouteTest extends TestCase {
@@ -106,7 +106,7 @@ class RouteTest extends TestCase {
 		$this->assertConditionsMet();
 	}
 
-	public function test_get_400_response() {
+	public function test_get_error_response() {
 		$request = Mockery::mock( WP_REST_Request::class )
 			->makePartial();
 
@@ -120,7 +120,7 @@ class RouteTest extends TestCase {
 		// Just mock this, so that WP_Error exists.
 		$wp_error = Mockery::mock( WP_Error::class )->makePartial();
 
-		$error_response = $this->route->get_400_response( 'Post ID not found.' );
+		$error_response = $this->route->get_error_response( 'Post ID not found.' );
 
 		$this->assertInstanceOf( WP_Error::class, $error_response );
 		$this->assertConditionsMet();

--- a/tests/php/Routes/ImportTest.php
+++ b/tests/php/Routes/ImportTest.php
@@ -14,7 +14,7 @@ use Badasswp\WPMockTC\WPMockTestCase;
  * @covers \ConvertBlocksToJSON\Routes\Import::rest_callback
  * @covers \ConvertBlocksToJSON\Routes\Import::get_blocks_import
  * @covers \ConvertBlocksToJSON\Routes\Import::get_import
- * @covers \ConvertBlocksToJSON\Abstracts\Route::get_400_response
+ * @covers \ConvertBlocksToJSON\Abstracts\Route::get_error_response
  */
 class ImportTest extends WPMockTestCase {
 	public Import $import;
@@ -55,6 +55,9 @@ class ImportTest extends WPMockTestCase {
 			->with( 0 )
 			->andReturn( '' );
 
+		Mockery::mock( WP_Error::class )
+			->makePartial();
+
 		$response = $this->import->rest_callback( $request );
 
 		$this->assertInstanceOf( WP_Error::class, $response );
@@ -84,6 +87,9 @@ class ImportTest extends WPMockTestCase {
 			);
 
 		$this->create_mock_file( $mock_file );
+
+		Mockery::mock( WP_Error::class )
+			->makePartial();
 
 		$response = $this->import->rest_callback( $request );
 


### PR DESCRIPTION
This PR resolves [WP-32](https://appworld.atlassian.net/browse/WP-32).

## Description / Background Context

We are currently using the `get_400_response` method for server errors. It makes sense for us to refactor this to a more general purpose (agnostic) method so that we can throw any type of error that is not strictly related to a `400`.

This PR refactors this method to use to a default `400` status code.

## Testing Instructions

- Pull PR to local.
- Run tests using `composer run test`.
- Observe that all test cases pass correctly.
- Head over to Posts and add a new post.
- Click on the **Convert Blocks to JSON** icon.
- Next, click the **Import JSON** button and **try to upload an image**.
- Observe that it correctly throws the error shown below:

---

<img width="355" height="158" alt="Screenshot 2026-02-03 at 08 34 13" src="https://github.com/user-attachments/assets/8fce6291-2f47-4325-a013-df77346f9004" />