### PR TITLE
Fix: Import issues with `core/list` and `core/list-item` blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,34 @@ public function custom_namespace( $namespace ): array {
 - namespace _`{string}`_ REST Namespace. By default, this is a string which contains the Route namespace.
 <br/>
 
+#### `cbtj.innerBlocks`
+
+This custom hook (filter) provides the ability to filter the way we create the inner blocks like so:
+
+```js
+import { addFilter } from '@wordpress/hooks';
+
+addFilter(
+    'cbtj.innerBlocks',
+    'yourNamespace',
+    ( innerBlocks, name ) => {
+        if ( 'my/custom-block' === name ) {
+            return innerBlocks.map( ( { name, attributes } ) =>
+                createBlock( name, { ...JSON.parse( attributes ) } )
+            );
+        }
+
+        return innerBlocks;
+    }
+);
+```
+
+**Parameters**
+
+- innerBlocks _`{any[]}`_ Array of inner blocks.
+- name _`{string}`_ Name of block.
+<br/>
+
 ---
 
 ## Contribute

--- a/inc/Blocks/ListItem.php
+++ b/inc/Blocks/ListItem.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * ListItem Block.
+ *
+ * This class is responsible for customizing
+ * the ListItem block output.
+ *
+ * @package ConvertBlocksToJSON
+ */
+
+namespace ConvertBlocksToJSON\Blocks;
+
+use ConvertBlocksToJSON\Abstracts\Block;
+
+class ListItem extends Block {
+	/**
+	 * Import Block.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed[] $block Import Block.
+	 * @return mixed[]
+	 */
+	public function import_block( $block ): array {
+		// Bail out, if undefined OR not ListItem block.
+		if ( empty( $block['name'] ) || 'core/list-item' !== $block['name'] ) {
+			return $block;
+		}
+
+		return [
+			'name'        => $block['name'] ?? '',
+			'attributes'  => $block['attributes'] ?? '{}',
+			'innerBlocks' => $block['innerBlocks'] ?? [],
+		];
+	}
+
+	/**
+	 * Export Block.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed[] $block Export Block.
+	 * @return mixed[]
+	 */
+	public function export_block( $block ): array {
+		// Bail out, if undefined OR not ListItem block.
+		if ( empty( $block['name'] ) || 'core/list-item' !== $block['name'] ) {
+			return $block;
+		}
+
+		return $block;
+	}
+}

--- a/inc/Blocks/Lists.php
+++ b/inc/Blocks/Lists.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * List Block.
+ *
+ * This class is responsible for customizing
+ * the List block output.
+ *
+ * @package ConvertBlocksToJSON
+ */
+
+namespace ConvertBlocksToJSON\Blocks;
+
+use ConvertBlocksToJSON\Abstracts\Block;
+
+class Lists extends Block {
+	/**
+	 * Import Block.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed[] $block Import Block.
+	 * @return mixed[]
+	 */
+	public function import_block( $block ): array {
+		// Bail out, if undefined OR not List block.
+		if ( empty( $block['name'] ) || 'core/list' !== $block['name'] ) {
+			return $block;
+		}
+
+		// Decode attributes correctly.
+		$block['attributes'] = json_decode( $block['attributes'] ?? '{}', true );
+
+		// Unset the content.
+		unset( $block['attributes']['content'] );
+
+		return [
+			'name'        => $block['name'] ?? '',
+			'attributes'  => wp_json_encode( $block['attributes'] ),
+			'innerBlocks' => $block['innerBlocks'] ?? [],
+		];
+	}
+
+	/**
+	 * Export Block.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed[] $block Export Block.
+	 * @return mixed[]
+	 */
+	public function export_block( $block ): array {
+		// Bail out, if undefined OR not List block.
+		if ( empty( $block['name'] ) || 'core/list' !== $block['name'] ) {
+			return $block;
+		}
+
+		return $block;
+	}
+}

--- a/inc/Services/Blocks.php
+++ b/inc/Services/Blocks.php
@@ -10,7 +10,10 @@
 
 namespace ConvertBlocksToJSON\Services;
 
+use ConvertBlocksToJSON\Blocks\Lists;
+use ConvertBlocksToJSON\Blocks\ListItem;
 use ConvertBlocksToJSON\Blocks\Image;
+
 use ConvertBlocksToJSON\Abstracts\Block;
 use ConvertBlocksToJSON\Abstracts\Service;
 use ConvertBlocksToJSON\Interfaces\Kernel;
@@ -34,6 +37,8 @@ class Blocks extends Service implements Kernel {
 	 */
 	public function __construct() {
 		$this->blocks = [
+			Lists::class,
+			ListItem::class,
 			Image::class,
 		];
 	}

--- a/src/components/ImportJSON.tsx
+++ b/src/components/ImportJSON.tsx
@@ -6,7 +6,7 @@ import { store as editorStore } from '@wordpress/editor';
 import { store as noticeStore } from '@wordpress/notices';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
-import { getModalParams, getImport } from '../utils';
+import { getModalParams, getImport, getInnerBlocks } from '../utils';
 
 /**
  * Import JSON.
@@ -66,7 +66,11 @@ const ImportJSON = (): JSX.Element => {
 				(
 					dispatch( blockEditorStore ) as { insertBlocks: any }
 				 ).insertBlocks(
-					createBlock( name, { ...attributes }, innerBlocks )
+					createBlock(
+						name,
+						{ ...attributes },
+						getInnerBlocks( { name, innerBlocks } )
+					)
 				);
 			} );
 

--- a/src/filters.tsx
+++ b/src/filters.tsx
@@ -1,0 +1,30 @@
+import { addFilter } from '@wordpress/hooks';
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Filter the way we handle the innerBlocks
+ * depending on the type of block.
+ *
+ * @since 1.3.0
+ *
+ * @param {any[]}  innerBlocks Inner Blocks.
+ * @param {string} block       Name of block.
+ *
+ * @return {any[]}
+ */
+addFilter( 'cbtj.innerBlocks', 'cbtj', ( innerBlocks, block ) => {
+	let blocks = [];
+
+	switch ( block ) {
+		case 'core/list':
+			blocks = innerBlocks.map( ( { name, attributes } ) =>
+				createBlock( name, { ...JSON.parse( attributes ) } )
+			);
+			break;
+
+		default:
+			break;
+	}
+
+	return blocks;
+} );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import ViewJSON from './components/ViewJSON';
 import ImportJSON from './components/ImportJSON';
 import ExportJSON from './components/ExportJSON';
 
+import './filters';
 import './styles/app.scss';
 
 /**

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { select } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
+import { applyFilters } from '@wordpress/hooks';
 import { store as editorStore } from '@wordpress/editor';
 
 /**
@@ -62,4 +63,36 @@ export const getModalParams = (): any => {
 		},
 		multiple: false,
 	};
+};
+
+/**
+ * Get Inner Blocks.
+ *
+ * This function returns created version of the inner
+ * blocks if they exist.
+ *
+ * @param  block
+ * @param  block.name        Name of block.
+ * @param  block.innerBlocks Inner blocks.
+ *
+ * @return {Array} Array of created blocks.
+ */
+export const getInnerBlocks = ( { name, innerBlocks } ): [] => {
+	// Bail out, if empty.
+	if ( ! innerBlocks.length ) {
+		return [];
+	}
+
+	/**
+	 * Filters the inner blocks depending on
+	 * what type of block it is.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param {any[]}  innerBlocks Inner blocks.
+	 * @param {string} name        Name of block.
+	 *
+	 * @return {Array}
+	 */
+	return applyFilters( 'cbtj.innerBlocks', innerBlocks, name ) as [];
 };

--- a/tests/php/Services/BlocksTest.php
+++ b/tests/php/Services/BlocksTest.php
@@ -76,7 +76,7 @@ class BlocksTest extends WPMockTestCase {
 			[
 				Lists::class,
 				ListItem::class,
-				Image::class
+				Image::class,
 			]
 		);
 

--- a/tests/php/Services/BlocksTest.php
+++ b/tests/php/Services/BlocksTest.php
@@ -5,9 +5,12 @@ namespace ConvertBlocksToJSON\Tests\Services;
 use Mockery;
 use WP_Mock;
 use Badasswp\WPMockTC\WPMockTestCase;
-use ConvertBlocksToJSON\Blocks\Image;
 use ConvertBlocksToJSON\Abstracts\Block;
 use ConvertBlocksToJSON\Services\Blocks;
+
+use ConvertBlocksToJSON\Blocks\Lists;
+use ConvertBlocksToJSON\Blocks\ListItem;
+use ConvertBlocksToJSON\Blocks\Image;
 
 /**
  * @covers \ConvertBlocksToJSON\Services\Blocks::__construct
@@ -31,6 +34,8 @@ class BlocksTest extends WPMockTestCase {
 	public function test_class_properties_are_defined_by_default() {
 		$this->assertSame(
 			[
+				Lists::class,
+				ListItem::class,
 				Image::class,
 			],
 			$this->blocks->blocks
@@ -66,7 +71,14 @@ class BlocksTest extends WPMockTestCase {
 	}
 
 	public function test_get_blocks() {
-		WP_Mock::expectFilter( 'cbtj_blocks', [ Image::class ] );
+		WP_Mock::expectFilter(
+			'cbtj_blocks',
+			[
+				Lists::class,
+				ListItem::class,
+				Image::class
+			]
+		);
 
 		$blocks = $this->blocks->get_blocks();
 


### PR DESCRIPTION
This PR resolves [WP-87](https://appworld.atlassian.net/browse/WP-87).

## Description / Background Context

When content is imported, list blocks (`core/list` and `core/list-item`) that exist in the exported file do not appear in the article after import. The process seems to skip these blocks completely, causing any list content to be lost.

This PR fixes #20.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn build`.
- Head over to Posts and add a new post.
- Try to import a list/list-item block.
- Observe that it correctly imports the block without any issues.

---

<img width="400" src="https://github.com/user-attachments/assets/0bf75b9a-9b23-4102-aa58-1d823f9ee8a1" />