### PR TITLE
Feat: Implement Image import for Remote websites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.3.0
 * Fix: Import issues with `core/list` and `core/list-item` blocks.
 * Feat: Add custom hook - `cbtj.innerBlocks`.
+* Feat: Implement Image import across websites.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Chore: Add pull request template to repo.
 * Docs: Update README docs.

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
 		"phpunit/phpunit": "^9.6",
 		"mockery/mockery": "^1.6",
 		"10up/wp_mock": "^1.0",
-		"badasswp/wp-mock-tc": "^1.0",
 		"wp-coding-standards/wpcs": "^3.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
 		"php-coveralls/php-coveralls": "^2.5",
 		"phpunit/phpcov": "^8.2",
 		"phpstan/phpstan": "^1.10",
 		"szepeviktor/phpstan-wordpress": "^1.3",
-		"phpstan/extension-installer": "^1.3"
+		"phpstan/extension-installer": "^1.3",
+		"badasswp/wp-mock-tc": "^1.1"
 	},
 	"config": {
 		"allow-plugins": {

--- a/inc/Blocks/Image.php
+++ b/inc/Blocks/Image.php
@@ -34,6 +34,15 @@ class Image extends Block {
 		preg_match( '/src="([^"]+)"/', $block['originalContent'] ?? '', $matches );
 		$block['attributes']['url'] = esc_url( $matches[1] ?? '' );
 
+		// If it's not same site, get remote image.
+		if ( false === strpos( $block['attributes']['url'] ?? '', home_url() ) ) {
+			$remote_image = $this->get_remote_image( $block['attributes']['url'] ?? '' );
+
+			if ( ! is_wp_error( $remote_image ) ) {
+				$block['attributes']['url'] = $remote_image;
+			}
+		}
+
 		// Re-encode attributes correctly.
 		$block['attributes'] = wp_json_encode( $block['attributes'] );
 
@@ -55,5 +64,97 @@ class Image extends Block {
 		}
 
 		return $block;
+	}
+
+	/**
+	 * Import Image.
+	 *
+	 * This is specific to importing images from
+	 * an external or remote website.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string $image_url Image URL.
+	 * @return string
+	 */
+	protected function get_remote_image( $image_url ): string {
+		if ( ! function_exists( 'download_url' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		if ( ! function_exists( 'wp_handle_sideload' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		if ( ! function_exists( 'wp_generate_attachment_metadata' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/image.php';
+		}
+
+		// Download the file to a temporary location.
+		$tmp_file = download_url( sanitize_url( $image_url ) );
+
+		// Bail out, if wp_error.
+		if ( is_wp_error( $tmp_file ) ) {
+			error_log(
+				sprintf(
+					'Import error: %s, %s',
+					$tmp_file->get_error_message() ?? '',
+					$image_url
+				)
+			);
+
+			return $tmp_file;
+		}
+
+		// Get the filename + extension from the URL.
+		$url_filename = basename( parse_url( $image_url, PHP_URL_PATH ) );
+
+		// Build an array that resembles a PHP file upload.
+		$file = [
+			'name'     => $url_filename,
+			'type'     => mime_content_type( $tmp_file ),
+			'tmp_name' => $tmp_file,
+			'error'    => 0,
+			'size'     => filesize( $tmp_file ),
+		];
+
+		// Let WordPress handle the sideload.
+		$overrides = [
+			'test_form'   => false,
+			'test_size'   => true,
+			'test_upload' => true,
+		];
+
+		$results = wp_handle_sideload( $file, $overrides );
+
+		// Bail out, if upload error.
+		if ( isset( $results['error'] ) ) {
+			@unlink( $tmp_file );
+			$error_message = sprintf( 'Import error: %s', $results['error'] ?? '' );
+			error_log( $error_message );
+
+			return new WP_Error( 'cbtj-import-error', $error_message );
+		}
+
+		// Now create attachment post for the image.
+		$attachment = [
+			'post_mime_type' => $results['type'],
+			'post_title'     => sanitize_file_name( pathinfo( $url_filename, PATHINFO_FILENAME ) ),
+			'post_content'   => '',
+			'post_status'    => 'inherit',
+		];
+
+		$attach_id = wp_insert_attachment( $attachment, $results['file'] );
+
+		// Bail out, if wp_error.
+		if ( is_wp_error( $attach_id ) ) {
+			return $attach_id;
+		}
+
+		// Generate attachment metadata.
+		$metadata = wp_generate_attachment_metadata( $attach_id, $results['file'] );
+		wp_update_attachment_metadata( $attach_id, $metadata );
+
+		return wp_get_attachment_url( $attach_id );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -73,6 +73,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 = 1.3.0 =
 * Fix: Import issues with `core/list` and `core/list-item` blocks.
 * Feat: Add custom hook - `cbtj.innerBlocks`.
+* Feat: Implement Image import across websites.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Chore: Add pull request template to repo.
 * Docs: Update README docs.

--- a/tests/php/Blocks/ImageTest.php
+++ b/tests/php/Blocks/ImageTest.php
@@ -15,6 +15,7 @@ class ImageTest extends WPMockTestCase {
 	public Image $image;
 
 	public function setUp(): void {
+		parent::override( [ 'is_wp_error' ] );
 		parent::setUp();
 
 		$this->image = new Image();
@@ -65,6 +66,9 @@ class ImageTest extends WPMockTestCase {
 	}
 
 	public function test_import_block_returns_modified_block_with_added_image_attribute() {
+		WP_Mock::userFunction( 'home_url' )
+			->andReturn( 'https://www.example.com' );
+
 		$block = $this->image->import_block(
 			[
 				'name'            => 'core/image',
@@ -80,6 +84,77 @@ class ImageTest extends WPMockTestCase {
 				'name'            => 'core/image',
 				'originalContent' => '<body><img src="https://www.example.com/wp-content/image.jpg"/></body>',
 				'attributes'      => '{"url":"https:\/\/www.example.com\/wp-content\/image.jpg"}',
+				'innerBlocks'     => [],
+			]
+		);
+	}
+
+	public function test_import_block_returns_modified_block_with_added_image_url_referencing_old_site_if_is_wp_error() {
+		$image = Mockery::mock( Image::class )->makePartial();
+		$image->shouldAllowMockingProtectedMethods();
+
+		$wp_error = Mockery::mock( WP_Error::class )->makePartial();
+		$wp_error->shouldAllowMockingProtectedMethods();
+
+		WP_Mock::userFunction( 'home_url' )
+			->andReturn( 'https://www.example.com' );
+
+		WP_Mock::userFunction( 'is_wp_error' )
+			->andReturn( true );
+
+		$image->shouldReceive( 'get_remote_image' )
+			->with( 'https://www.johndoe.com/wp-content/image.jpg' )
+			->andReturn( $wp_error );
+
+		$block = $image->import_block(
+			[
+				'name'            => 'core/image',
+				'originalContent' => '<body><img src="https://www.johndoe.com/wp-content/image.jpg"/></body>',
+				'attributes'      => '{}',
+				'innerBlocks'     => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'            => 'core/image',
+				'originalContent' => '<body><img src="https://www.johndoe.com/wp-content/image.jpg"/></body>',
+				'attributes'      => '{"url":"https:\/\/www.johndoe.com\/wp-content\/image.jpg"}',
+				'innerBlocks'     => [],
+			]
+		);
+	}
+
+	public function test_import_block_returns_modified_block_with_newly_imported_image_from_remote_site() {
+		$image = Mockery::mock( Image::class )->makePartial();
+		$image->shouldAllowMockingProtectedMethods();
+
+		WP_Mock::userFunction( 'home_url' )
+			->andReturn( 'https://www.example.com' );
+
+		WP_Mock::userFunction( 'is_wp_error' )
+			->andReturn( false );
+
+		$image->shouldReceive( 'get_remote_image' )
+			->with( 'https://www.johndoe.com/wp-content/image.jpg' )
+			->andReturn( 'https://www.example.com/wp-content/imported-image.jpg' );
+
+		$block = $image->import_block(
+			[
+				'name'            => 'core/image',
+				'originalContent' => '<body><img src="https://www.johndoe.com/wp-content/image.jpg"/></body>',
+				'attributes'      => '{}',
+				'innerBlocks'     => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'            => 'core/image',
+				'originalContent' => '<body><img src="https://www.johndoe.com/wp-content/image.jpg"/></body>',
+				'attributes'      => '{"url":"https:\/\/www.example.com\/wp-content\/imported-image.jpg"}',
 				'innerBlocks'     => [],
 			]
 		);


### PR DESCRIPTION
This PR resolves [WP-28](https://appworld.atlassian.net/browse/WP-28).

## Description / Background Context

At the moment, the plugin only supports the image import for same website, we need to introduce logic that allows for image import across different websites.

This PR implements same.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn build`.
- Head over to `tastewp.com` [here](https://tastewp.com/create/NMS/8.0/6.7.0/convert-blocks-to-json/twentytwentythree?ni=true&origin=wp) and spin up a new WP instance.
- Now create a post and insert an image block with an image and publish the post.
- Locate the `Convert Blocks to JSON` icon and export the blocks into a JSON file.
- Go back to your local environment and import the JSON file.
- Observe that imports the post correctly and adds the image you just imported.
- Observe that in the Media Library the image you just imported is also present.
- Run `composer run test`.
- Observe that all test cases pass correctly.