### PR TITLE
Chore: Fix incorrectly quoted Translations bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 1.3.0
+* Chore: Fixed incorrectly quoted translation bits.
 * Feat: Added language translations for Japanese, Indonesia, Turkish, Polish, Dutch, Danish, Brazil, Portuguese.
 * Fix: Import issues with `core/list` and `core/list-item` blocks.
 * Feat: Add custom hook - `cbtj.innerBlocks`.

--- a/languages/convert-blocks-to-json-ar.po
+++ b/languages/convert-blocks-to-json-ar.po
@@ -34,7 +34,7 @@ msgstr "قم بتحويل كتل WP إلى JSON."
 
 #. Author
 msgid "badasswp"
-msgstr "‫badasswp"
+msgstr "badasswp"
 
 #. Author URI
 msgid "https://github.com/badasswp"

--- a/languages/convert-blocks-to-json-he_IL.po
+++ b/languages/convert-blocks-to-json-he_IL.po
@@ -34,7 +34,7 @@ msgstr "המר את בלוקי WP שלך ל- JSON."
 
 #. Author
 msgid "badasswp"
-msgstr "‫badasswp"
+msgstr "badasswp"
 
 #. Author URI
 msgid "https://github.com/badasswp"

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 == Changelog ==
 
 = 1.3.0 =
+* Chore: Fixed incorrectly quoted translation bits.
 * Feat: Added language translations for Japanese, Indonesia, Turkish, Polish, Dutch, Danish, Brazil, Portuguese.
 * Fix: Import issues with `core/list` and `core/list-item` blocks.
 * Feat: Add custom hook - `cbtj.innerBlocks`.


### PR DESCRIPTION
This PR resolves [WP-121](https://appworld.atlassian.net/browse/WP-121).

## Description / Background Context

There exist some translations which has incorrect quote, this PR ensures that all translation with such error has been fixed.

## Testing Instructions

- Pull PR to local.
- Proceed to removing the hidden unicode text which causes misinterpretation.
- Observe that all the translations files are no longer housing any unicode.