### PR TITLE
Feat: Added scaffold paragraph class in Blocks folder

### DIFF
--- a/inc/Blocks/Paragraph.php
+++ b/inc/Blocks/Paragraph.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Paragraph Block
+ *
+ * This class is responsible for customizing
+ * the paragraph block output
+ *
+ * @package ConvertBlocksToJSON
+ */
+
+namespace ConvertBlocksToJSON\Blocks;
+
+use ConvertBlocksToJSON\Abstracts\Block;
+
+class Paragraph extends Block {
+	/**
+	 * Import Block.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed[] $block Import Block.
+	 * @return mixed[]
+	 */
+	public function import_block( $block ): array {
+		//Bail out, if undefined OR not Paragraph block.
+		if ( empty( $block['name'] ) || 'core/paragraph' !== $block['name'] ){
+			return $block;
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Export Block
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed $block Export Block.
+	 * @return mixed[]
+	 */
+	public function export_block( $block ): array {
+		//Bail out, if undefined OR not paragraph block.
+		if ( empty( $block['name'] ) || 'core/paragraph' !== $block['name'] ){
+			return $block;
+		}
+
+		return $block;
+	}
+}

--- a/inc/Blocks/Paragraph.php
+++ b/inc/Blocks/Paragraph.php
@@ -23,7 +23,7 @@ class Paragraph extends Block {
 	 */
 	public function import_block( $block ): array {
 		//Bail out, if undefined OR not Paragraph block.
-		if ( empty( $block['name'] ) || 'core/paragraph' !== $block['name'] ){
+		if ( empty( $block['name'] ) || 'core/paragraph' !== $block['name'] ) {
 			return $block;
 		}
 
@@ -40,7 +40,7 @@ class Paragraph extends Block {
 	 */
 	public function export_block( $block ): array {
 		//Bail out, if undefined OR not paragraph block.
-		if ( empty( $block['name'] ) || 'core/paragraph' !== $block['name'] ){
+		if ( empty( $block['name'] ) || 'core/paragraph' !== $block['name'] ) {
 			return $block;
 		}
 


### PR DESCRIPTION
This PR resolves [WP-123](https://appworld.atlassian.net/browse/WP-123).

## Description / Background Context

At the moment, there is no paragraph class for importing paragraph block
This PR ensures that there exist a scaffolded paragraph class.

## Testing Instructions

- Pull PR to local.
- Proceed to `inc/blocks/` folder.
- Observe that there is a file named `Paragraph.php` in the folder

