### PR TITLE
Refactor: Import class to not include `originalContent`, fix paragraph block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Feat: Add custom hook - `cbtj.innerBlocks`.
 * Feat: Add Notification modal during import.
 * Fix: Import issues with `core/list` and `core/list-item` blocks.
+* Fix: Import issues with `core/pargraph` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/inc/Abstracts/Block.php
+++ b/inc/Abstracts/Block.php
@@ -46,4 +46,16 @@ abstract class Block {
 		add_filter( 'cbtj_import_block', [ $this, 'import_block' ] );
 		add_filter( 'cbtj_export_block', [ $this, 'export_block' ] );
 	}
+
+	/**
+	 * Get clean markup.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string $markup Dirty markup.
+	 * @return string
+	 */
+	public function get_clean_markup( $markup ) {
+		return preg_replace( sprintf( '/<\/?%s\b[^>]*>/', $this->tag ?? '' ), '', $markup );
+	}
 }

--- a/inc/Blocks/Image.php
+++ b/inc/Blocks/Image.php
@@ -31,7 +31,7 @@ class Image extends Block {
 		$block['attributes'] = json_decode( $block['attributes'] ?? '', true );
 
 		// Ensure missing URL attribute is captured for image blocks.
-		preg_match( '/src="([^"]+)"/', $block['originalContent'] ?? '', $matches );
+		preg_match( '/src="([^"]+)"/', $block['attributes']['content'] ?? '', $matches );
 		$block['attributes']['url'] = esc_url( $matches[1] ?? '' );
 
 		// If it's not same site, get remote image.
@@ -75,9 +75,9 @@ class Image extends Block {
 	 * @since 1.3.0
 	 *
 	 * @param string $image_url Image URL.
-	 * @return string
+	 * @return string|\WP_Error
 	 */
-	protected function get_remote_image( $image_url ): string {
+	protected function get_remote_image( $image_url ) {
 		if ( ! function_exists( 'download_url' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';
 		}

--- a/inc/Blocks/ListItem.php
+++ b/inc/Blocks/ListItem.php
@@ -14,6 +14,15 @@ use ConvertBlocksToJSON\Abstracts\Block;
 
 class ListItem extends Block {
 	/**
+	 * Element name.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @var string
+	 */
+	public string $tag = 'li';
+
+	/**
 	 * Import Block.
 	 *
 	 * @since 1.3.0
@@ -27,9 +36,15 @@ class ListItem extends Block {
 			return $block;
 		}
 
+		// Decode attributes correctly.
+		$block['attributes'] = json_decode( $block['attributes'] ?? '{}', true );
+
+		// Set the content.
+		$block['attributes']['content'] = $this->get_clean_markup( $block['attributes']['content'] ?? '' );
+
 		return [
 			'name'        => $block['name'] ?? '',
-			'attributes'  => $block['attributes'] ?? '{}',
+			'attributes'  => wp_json_encode( $block['attributes'] ?? [] ),
 			'innerBlocks' => $block['innerBlocks'] ?? [],
 		];
 	}

--- a/inc/Blocks/Paragraph.php
+++ b/inc/Blocks/Paragraph.php
@@ -3,7 +3,7 @@
  * Paragraph Block
  *
  * This class is responsible for customizing
- * the paragraph block output
+ * the Paragraph block output.
  *
  * @package ConvertBlocksToJSON
  */
@@ -13,6 +13,15 @@ namespace ConvertBlocksToJSON\Blocks;
 use ConvertBlocksToJSON\Abstracts\Block;
 
 class Paragraph extends Block {
+	/**
+	 * Element name.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @var string
+	 */
+	public string $tag = 'p';
+
 	/**
 	 * Import Block.
 	 *
@@ -26,6 +35,18 @@ class Paragraph extends Block {
 		if ( empty( $block['name'] ) || 'core/paragraph' !== $block['name'] ) {
 			return $block;
 		}
+
+		// Decode attributes correctly.
+		$block['attributes'] = json_decode( $block['attributes'] ?? '{}', true );
+
+		// Set the content.
+		$block['attributes']['content'] = $this->get_clean_markup( $block['attributes']['content'] ?? '' );
+
+		return [
+			'name'        => $block['name'] ?? '',
+			'attributes'  => wp_json_encode( $block['attributes'] ?? [] ),
+			'innerBlocks' => $block['innerBlocks'] ?? [],
+		];
 
 		return $block;
 	}

--- a/inc/Routes/Import.php
+++ b/inc/Routes/Import.php
@@ -144,13 +144,13 @@ class Import extends Route implements Router {
 			}
 		}
 
-		$block['attributes']['content'] = $block['filtered'] ?? '';
+		// Use innerHTML for block content.
+		$block['attributes']['content'] = trim( $block['content'] ?? '' );
 
 		$import_block = [
-			'name'            => $block['name'] ?? '',
-			'originalContent' => $block['content'] ?? '',
-			'attributes'      => wp_json_encode( $block['attributes'] ?? [] ),
-			'innerBlocks'     => $children ?? [],
+			'name'        => $block['name'] ?? '',
+			'attributes'  => wp_json_encode( $block['attributes'] ?? [] ),
+			'innerBlocks' => $children ?? [],
 		];
 
 		/**

--- a/inc/Services/Blocks.php
+++ b/inc/Services/Blocks.php
@@ -13,6 +13,7 @@ namespace ConvertBlocksToJSON\Services;
 use ConvertBlocksToJSON\Blocks\Lists;
 use ConvertBlocksToJSON\Blocks\ListItem;
 use ConvertBlocksToJSON\Blocks\Image;
+use ConvertBlocksToJSON\Blocks\Paragraph;
 
 use ConvertBlocksToJSON\Abstracts\Block;
 use ConvertBlocksToJSON\Abstracts\Service;
@@ -40,6 +41,7 @@ class Blocks extends Service implements Kernel {
 			Lists::class,
 			ListItem::class,
 			Image::class,
+			Paragraph::class,
 		];
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 * Feat: Add custom hook - `cbtj.innerBlocks`.
 * Feat: Add Notification modal during import.
 * Fix: Import issues with `core/list` and `core/list-item` blocks.
+* Fix: Import issues with `core/pargraph` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/src/components/ImportJSON.tsx
+++ b/src/components/ImportJSON.tsx
@@ -47,6 +47,11 @@ const ImportJSON = (): JSX.Element => {
 	 * @return {Promise<void>}
 	 */
 	const handleImport = async ( wpMediaModal: any ): Promise< void > => {
+		const { editPost, savePost } = dispatch( editorStore ) as {
+			editPost: any;
+			savePost: any;
+		};
+
 		dispatch( noticeStore ).createNotice(
 			'info',
 			__(
@@ -59,6 +64,7 @@ const ImportJSON = (): JSX.Element => {
 				type: 'snackbar',
 			}
 		);
+
 		const attachment = wpMediaModal
 			.state()
 			.get( 'selection' )
@@ -70,7 +76,7 @@ const ImportJSON = (): JSX.Element => {
 			const { title, content } = await getImport( attachment );
 
 			// Add title.
-			dispatch( editorStore ).editPost( { title, status: 'publish' } );
+			editPost( { title, status: 'publish' } );
 
 			// Add content.
 			content.forEach( ( { name, attributes, innerBlocks } ) => {
@@ -87,7 +93,7 @@ const ImportJSON = (): JSX.Element => {
 			} );
 
 			// Save Post.
-			await dispatch( editorStore ).savePost();
+			await savePost();
 			dispatch( noticeStore ).removeNotice( 'cbtj-info' );
 		} catch ( e ) {
 			dispatch( noticeStore ).createWarningNotice( e.message );

--- a/src/typings/wp.d.ts
+++ b/src/typings/wp.d.ts
@@ -12,3 +12,4 @@ declare namespace wp {
 }
 
 declare module '@wordpress/editor';
+declare module '@wordpress/block-editor';

--- a/tests/unit/php/Blocks/ImageTest.php
+++ b/tests/unit/php/Blocks/ImageTest.php
@@ -28,18 +28,16 @@ class ImageTest extends WPMockTestCase {
 	public function test_import_block_returns_default_block_if_name_is_undefined() {
 		$block = $this->image->import_block(
 			[
-				'attributes'      => '{}',
-				'originalContent' => '',
-				'innerBlocks'     => [],
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
 			]
 		);
 
 		$this->assertSame(
 			$block,
 			[
-				'attributes'      => '{}',
-				'originalContent' => '',
-				'innerBlocks'     => [],
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
 			]
 		);
 	}
@@ -47,20 +45,18 @@ class ImageTest extends WPMockTestCase {
 	public function test_import_block_returns_default_block_if_block_is_not_paragraph() {
 		$block = $this->image->import_block(
 			[
-				'name'            => 'core/paragraph',
-				'attributes'      => '{}',
-				'originalContent' => '',
-				'innerBlocks'     => [],
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
 			]
 		);
 
 		$this->assertSame(
 			$block,
 			[
-				'name'            => 'core/paragraph',
-				'attributes'      => '{}',
-				'originalContent' => '',
-				'innerBlocks'     => [],
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
 			]
 		);
 	}
@@ -71,20 +67,18 @@ class ImageTest extends WPMockTestCase {
 
 		$block = $this->image->import_block(
 			[
-				'name'            => 'core/image',
-				'originalContent' => '<body><img src="https://www.example.com/wp-content/image.jpg"/></body>',
-				'attributes'      => '{}',
-				'innerBlocks'     => [],
+				'name'        => 'core/image',
+				'attributes'  => '{"content":"<body><img src=\"https:\/\/www.example.com\/wp-content\/image.jpg\"\/><\/body>"}',
+				'innerBlocks' => [],
 			]
 		);
 
 		$this->assertSame(
 			$block,
 			[
-				'name'            => 'core/image',
-				'originalContent' => '<body><img src="https://www.example.com/wp-content/image.jpg"/></body>',
-				'attributes'      => '{"url":"https:\/\/www.example.com\/wp-content\/image.jpg"}',
-				'innerBlocks'     => [],
+				'name'        => 'core/image',
+				'attributes'  => '{"content":"<body><img src=\"https:\/\/www.example.com\/wp-content\/image.jpg\"\/><\/body>","url":"https:\/\/www.example.com\/wp-content\/image.jpg"}',
+				'innerBlocks' => [],
 			]
 		);
 	}
@@ -108,20 +102,18 @@ class ImageTest extends WPMockTestCase {
 
 		$block = $image->import_block(
 			[
-				'name'            => 'core/image',
-				'originalContent' => '<body><img src="https://www.johndoe.com/wp-content/image.jpg"/></body>',
-				'attributes'      => '{}',
-				'innerBlocks'     => [],
+				'name'        => 'core/image',
+				'attributes'  => '{"content":"<body><img src=\"https:\/\/www.johndoe.com\/wp-content\/image.jpg\"\/><\/body>"}',
+				'innerBlocks' => [],
 			]
 		);
 
 		$this->assertSame(
 			$block,
 			[
-				'name'            => 'core/image',
-				'originalContent' => '<body><img src="https://www.johndoe.com/wp-content/image.jpg"/></body>',
-				'attributes'      => '{"url":"https:\/\/www.johndoe.com\/wp-content\/image.jpg"}',
-				'innerBlocks'     => [],
+				'name'        => 'core/image',
+				'attributes'  => '{"content":"<body><img src=\"https:\/\/www.johndoe.com\/wp-content\/image.jpg\"\/><\/body>","url":"https:\/\/www.johndoe.com\/wp-content\/image.jpg"}',
+				'innerBlocks' => [],
 			]
 		);
 	}
@@ -142,20 +134,18 @@ class ImageTest extends WPMockTestCase {
 
 		$block = $image->import_block(
 			[
-				'name'            => 'core/image',
-				'originalContent' => '<body><img src="https://www.johndoe.com/wp-content/image.jpg"/></body>',
-				'attributes'      => '{}',
-				'innerBlocks'     => [],
+				'name'        => 'core/image',
+				'attributes'  => '{"content":"<body><img src=\"https:\/\/www.johndoe.com\/wp-content\/image.jpg\"\/><\/body>"}',
+				'innerBlocks' => [],
 			]
 		);
 
 		$this->assertSame(
 			$block,
 			[
-				'name'            => 'core/image',
-				'originalContent' => '<body><img src="https://www.johndoe.com/wp-content/image.jpg"/></body>',
-				'attributes'      => '{"url":"https:\/\/www.example.com\/wp-content\/imported-image.jpg"}',
-				'innerBlocks'     => [],
+				'name'        => 'core/image',
+				'attributes'  => '{"content":"<body><img src=\"https:\/\/www.johndoe.com\/wp-content\/image.jpg\"\/><\/body>","url":"https:\/\/www.example.com\/wp-content\/imported-image.jpg"}',
+				'innerBlocks' => [],
 			]
 		);
 	}

--- a/tests/unit/php/Routes/ImportTest.php
+++ b/tests/unit/php/Routes/ImportTest.php
@@ -109,7 +109,7 @@ class ImportTest extends WPMockTestCase {
 					[],
 					[
 						'name'        => 'core/paragraph',
-						'content'     => '<p>Block with name</p>',
+						'content'     => "\n<p>Block with name</p>\n",
 						'filtered'    => 'Block with name',
 						'attributes'  => [],
 						'innerBlocks' => [],
@@ -147,10 +147,9 @@ class ImportTest extends WPMockTestCase {
 		WP_Mock::expectFilter(
 			'cbtj_import_block',
 			[
-				'name'            => 'core/paragraph',
-				'originalContent' => '<p>Block with name</p>',
-				'attributes'      => '{"content":"Block with name"}',
-				'innerBlocks'     => [],
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":"<p>Block with name<\/p>"}',
+				'innerBlocks' => [],
 			]
 		);
 
@@ -159,10 +158,9 @@ class ImportTest extends WPMockTestCase {
 			[
 				'title'   => 'Hello World',
 				'content' => [
-					'name'            => 'core/paragraph',
-					'originalContent' => '<p>Block with name</p>',
-					'attributes'      => '{"content":"Block with name"}',
-					'innerBlocks'     => [],
+					'name'        => 'core/paragraph',
+					'attributes'  => '{"content":"<p>Block with name<\/p>"}',
+					'innerBlocks' => [],
 				],
 			],
 			1
@@ -186,7 +184,7 @@ class ImportTest extends WPMockTestCase {
 			[],
 			[
 				'name'        => 'core/paragraph',
-				'content'     => '<p>Block with name</p>',
+				'content'     => "\n<p>Block with name</p>\n",
 				'filtered'    => 'Block with name',
 				'attributes'  => [],
 				'innerBlocks' => [],
@@ -203,10 +201,9 @@ class ImportTest extends WPMockTestCase {
 		WP_Mock::expectFilter(
 			'cbtj_import_block',
 			[
-				'name'            => 'core/paragraph',
-				'originalContent' => '<p>Block with name</p>',
-				'attributes'      => '{"content":"Block with name"}',
-				'innerBlocks'     => [],
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":"<p>Block with name<\/p>"}',
+				'innerBlocks' => [],
 			]
 		);
 
@@ -217,10 +214,9 @@ class ImportTest extends WPMockTestCase {
 			[
 				[],
 				[
-					'name'            => 'core/paragraph',
-					'originalContent' => '<p>Block with name</p>',
-					'attributes'      => '{"content":"Block with name"}',
-					'innerBlocks'     => [],
+					'name'        => 'core/paragraph',
+					'attributes'  => '{"content":"<p>Block with name<\/p>"}',
+					'innerBlocks' => [],
 				],
 				[],
 				[],
@@ -246,7 +242,7 @@ class ImportTest extends WPMockTestCase {
 	public function test_get_import_returns_filtered_block_correctly() {
 		$block = [
 			'name'        => 'core/paragraph',
-			'content'     => '<p>Block with name</p>',
+			'content'     => "\n<p>Block with name</p>\n",
 			'filtered'    => 'Block with name',
 			'attributes'  => [],
 			'innerBlocks' => [],
@@ -255,10 +251,9 @@ class ImportTest extends WPMockTestCase {
 		WP_Mock::expectFilter(
 			'cbtj_import_block',
 			[
-				'name'            => 'core/paragraph',
-				'originalContent' => '<p>Block with name</p>',
-				'attributes'      => '{"content":"Block with name"}',
-				'innerBlocks'     => [],
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":"<p>Block with name<\/p>"}',
+				'innerBlocks' => [],
 			]
 		);
 
@@ -267,10 +262,9 @@ class ImportTest extends WPMockTestCase {
 		$this->assertSame(
 			$response,
 			[
-				'name'            => 'core/paragraph',
-				'originalContent' => '<p>Block with name</p>',
-				'attributes'      => '{"content":"Block with name"}',
-				'innerBlocks'     => [],
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":"<p>Block with name<\/p>"}',
+				'innerBlocks' => [],
 			]
 		);
 		$this->assertConditionsMet();

--- a/tests/unit/php/Services/BlocksTest.php
+++ b/tests/unit/php/Services/BlocksTest.php
@@ -11,6 +11,7 @@ use ConvertBlocksToJSON\Services\Blocks;
 use ConvertBlocksToJSON\Blocks\Lists;
 use ConvertBlocksToJSON\Blocks\ListItem;
 use ConvertBlocksToJSON\Blocks\Image;
+use ConvertBlocksToJSON\Blocks\Paragraph;
 
 /**
  * @covers \ConvertBlocksToJSON\Services\Blocks::__construct
@@ -37,6 +38,7 @@ class BlocksTest extends WPMockTestCase {
 				Lists::class,
 				ListItem::class,
 				Image::class,
+				Paragraph::class,
 			],
 			$this->blocks->blocks
 		);
@@ -77,6 +79,7 @@ class BlocksTest extends WPMockTestCase {
 				Lists::class,
 				ListItem::class,
 				Image::class,
+				Paragraph::class,
 			]
 		);
 


### PR DESCRIPTION
This PR resolves [WP-122](https://appworld.atlassian.net/browse/WP-122).

## Description / Background Context

We need to make the `Import` class to be extremely generic/agnostic. We will need to remove the `originalContent` and leave only the generic fields like `name`, `attributes` & `innerBlocks`.

This PR implements this correctly and builds off the work done in [123](https://github.com/badasswp/convert-blocks-to-json/pull/31) to fix the Paragraph block issues at the same time

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn install && yarn build`.
- Head over to `tastewp.com` [here](https://tastewp.com/create/NMS/8.0/6.7.0/convert-blocks-to-json/twentytwentythree?ni=true&origin=wp) and spin up a new WP instance.
- Now create a post and insert a paragraph, list-item & image block and publish the post.
- Please make sure to **make the paragraph bold**.
- Locate the `Convert Blocks to JSON` icon and export the blocks into a JSON file.
- (**For Engineers**) - Go back to your local environment and import the JSON file. (**For QA**) please use the [aw-wp-env.com](https://aw-wp-env.com/wp-admin/) test server) and import the JSON file.
- Observe that the Paragraph block is now working correctly and shows as bold when imported.
- Observe that image and list-item blocks are importing correctly without any regressions.

---

<img width="1723" height="900" alt="Screenshot 2026-02-14 at 11 35 00" src="https://github.com/user-attachments/assets/3d286a2d-24b2-4ced-8a46-33a3220802ea" />