### PR TITLE
Fix: Heading block import issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Feat: Add Notification modal during import.
 * Fix: Import issues with `core/list` and `core/list-item` blocks.
 * Fix: Import issues with `core/pargraph` block.
+* Fix: Import issues with `core/heading` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/inc/Blocks/Heading.php
+++ b/inc/Blocks/Heading.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Heading Block
+ *
+ * This class is responsible for customizing
+ * the Heading block output.
+ *
+ * @package ConvertBlocksToJSON
+ */
+
+namespace ConvertBlocksToJSON\Blocks;
+
+use ConvertBlocksToJSON\Abstracts\Block;
+
+class Heading extends Block {
+	/**
+	 * Element name.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @var string
+	 */
+	public string $tag = '(h1|h2|h3|h4|h5|h6)';
+
+	/**
+	 * Import Block.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed[] $block Import Block.
+	 * @return mixed[]
+	 */
+	public function import_block( $block ): array {
+		//Bail out, if undefined OR not Heading block.
+		if ( empty( $block['name'] ) || 'core/heading' !== $block['name'] ) {
+			return $block;
+		}
+
+		// Decode attributes correctly.
+		$block['attributes'] = json_decode( $block['attributes'] ?? '{}', true );
+
+		// Set the content.
+		$block['attributes']['content'] = $this->get_clean_markup( $block['attributes']['content'] ?? '' );
+
+		return [
+			'name'        => $block['name'] ?? '',
+			'attributes'  => wp_json_encode( $block['attributes'] ?? [] ),
+			'innerBlocks' => $block['innerBlocks'] ?? [],
+		];
+
+		return $block;
+	}
+
+	/**
+	 * Export Block
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed $block Export Block.
+	 * @return mixed[]
+	 */
+	public function export_block( $block ): array {
+		//Bail out, if undefined OR not Heading block.
+		if ( empty( $block['name'] ) || 'core/heading' !== $block['name'] ) {
+			return $block;
+		}
+
+		return $block;
+	}
+}

--- a/inc/Services/Blocks.php
+++ b/inc/Services/Blocks.php
@@ -10,6 +10,7 @@
 
 namespace ConvertBlocksToJSON\Services;
 
+use ConvertBlocksToJSON\Blocks\Heading;
 use ConvertBlocksToJSON\Blocks\Lists;
 use ConvertBlocksToJSON\Blocks\ListItem;
 use ConvertBlocksToJSON\Blocks\Image;
@@ -38,6 +39,7 @@ class Blocks extends Service implements Kernel {
 	 */
 	public function __construct() {
 		$this->blocks = [
+			Heading::class,
 			Lists::class,
 			ListItem::class,
 			Image::class,

--- a/readme.txt
+++ b/readme.txt
@@ -77,6 +77,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 * Feat: Add Notification modal during import.
 * Fix: Import issues with `core/list` and `core/list-item` blocks.
 * Fix: Import issues with `core/pargraph` block.
+* Fix: Import issues with `core/heading` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/tests/unit/php/Abstracts/BlockTest.php
+++ b/tests/unit/php/Abstracts/BlockTest.php
@@ -36,9 +36,47 @@ class BlockTest extends TestCase {
 
 		$this->assertConditionsMet();
 	}
+
+	public function test_get_clean_markup_removes_dirty_markup_with_no_attributes() {
+		$block      = new ConcreteBlock();
+		$block->tag = 'p';
+
+		$expected = $block->get_clean_markup( '<p>The <mark style="background-color:rgba(0, 0, 0, 0);color:#ff6900" class="has-inline-color">rough</mark> driver...</p>' );
+
+		$this->assertSame(
+			$expected,
+			'The <mark style="background-color:rgba(0, 0, 0, 0);color:#ff6900" class="has-inline-color">rough</mark> driver...'
+		);
+	}
+
+	public function test_get_clean_markup_removes_dirty_markup_with_attributes() {
+		$block      = new ConcreteBlock();
+		$block->tag = 'h2';
+
+		$expected = $block->get_clean_markup( '<h2 class="wp-block-heading"><h2 class="wp-block-heading">The <mark style="background-color:rgba(0, 0, 0, 0);color:#ff6900" class="has-inline-color">rough</mark> driver...</h2></h2>' );
+
+		$this->assertSame(
+			$expected,
+			'The <mark style="background-color:rgba(0, 0, 0, 0);color:#ff6900" class="has-inline-color">rough</mark> driver...'
+		);
+	}
+
+	public function test_get_clean_markup_removes_dirty_markup_with_attributes_using_regexp_as_tag() {
+		$block      = new ConcreteBlock();
+		$block->tag = '(h1|h2|h3|h4|h5|h6)';
+
+		$expected = $block->get_clean_markup( '<h2 class="wp-block-heading"><h2 class="wp-block-heading">The <mark style="background-color:rgba(0, 0, 0, 0);color:#ff6900" class="has-inline-color">rough</mark> driver...</h2></h2>' );
+
+		$this->assertSame(
+			$expected,
+			'The <mark style="background-color:rgba(0, 0, 0, 0);color:#ff6900" class="has-inline-color">rough</mark> driver...'
+		);
+	}
 }
 
 class ConcreteBlock extends Block {
+	public string $tag;
+
 	public function import_block( $block ): array {
 		return $block;
 	}

--- a/tests/unit/php/Abstracts/BlockTest.php
+++ b/tests/unit/php/Abstracts/BlockTest.php
@@ -9,6 +9,7 @@ use ConvertBlocksToJSON\Abstracts\Block;
 
 /**
  * @covers \ConvertBlocksToJSON\Abstracts\Block::init
+ * @covers \ConvertBlocksToJSON\Abstracts\Block::get_clean_markup
  */
 class BlockTest extends TestCase {
 	public function setUp(): void {

--- a/tests/unit/php/Services/BlocksTest.php
+++ b/tests/unit/php/Services/BlocksTest.php
@@ -8,6 +8,7 @@ use Badasswp\WPMockTC\WPMockTestCase;
 use ConvertBlocksToJSON\Abstracts\Block;
 use ConvertBlocksToJSON\Services\Blocks;
 
+use ConvertBlocksToJSON\Blocks\Heading;
 use ConvertBlocksToJSON\Blocks\Lists;
 use ConvertBlocksToJSON\Blocks\ListItem;
 use ConvertBlocksToJSON\Blocks\Image;
@@ -35,6 +36,7 @@ class BlocksTest extends WPMockTestCase {
 	public function test_class_properties_are_defined_by_default() {
 		$this->assertSame(
 			[
+				Heading::class,
 				Lists::class,
 				ListItem::class,
 				Image::class,
@@ -76,6 +78,7 @@ class BlocksTest extends WPMockTestCase {
 		WP_Mock::expectFilter(
 			'cbtj_blocks',
 			[
+				Heading::class,
 				Lists::class,
 				ListItem::class,
 				Image::class,


### PR DESCRIPTION
This PR resolves [WP-124](https://appworld.atlassian.net/browse/WP-124).

## Description / Background Context

At the moment, when we import a Heading block, we see that the block shows a warning icon citing a possible **unknown formatting** issue. This should not be the case. The expected behaviour should be that when the block is imported it shows correctly without any warning icon like so:

---

<img width="864" height="196" alt="heading-block" src="https://github.com/user-attachments/assets/455931a7-94b7-4b45-8582-1e53612f2c0b" />

This PR implements a fix for this issue.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn install && yarn build`.
- Head over to `tastewp.com` [here](https://tastewp.com/create/NMS/8.0/6.7.0/convert-blocks-to-json/twentytwentythree?ni=true&origin=wp) and spin up a new WP instance.
- Now create a heading block and publish the post.
- Locate the `Convert Blocks to JSON` icon and export the blocks into a JSON file.
- (**For Engineers**) - Go back to your local environment and import the JSON file. (**For QA**) please use the [test](https://aw-wp-env.com/wp-admin/) server and import the JSON file.
- Observe that the Heading block is now working correctly with no **unknown formatting** issue warning icon.

---

<img width="609" height="266" alt="Screenshot 2026-02-14 at 12 25 23" src="https://github.com/user-attachments/assets/e85a5950-8215-47de-a8f6-3e2c661bca2e" />
