### PR TITLE
Fix: Cover block import issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix: Import issues with `core/pargraph` block.
 * Fix: Import issues with `core/heading` block.
 * Fix: Import issues with `core/details` block.
+* Fix: Import issues with `core/cover` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 * Fix: Import issues with `core/pargraph` block.
 * Fix: Import issues with `core/heading` block.
 * Fix: Import issues with `core/details` block.
+* Fix: Import issues with `core/cover` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/src/filters.tsx
+++ b/src/filters.tsx
@@ -18,6 +18,7 @@ addFilter( 'cbtj.innerBlocks', 'cbtj', ( innerBlocks, block ) => {
 	switch ( block ) {
 		case 'core/list':
 		case 'core/details':
+		case 'core/cover':
 			blocks = innerBlocks.map( ( { name, attributes } ) =>
 				createBlock( name, { ...JSON.parse( attributes ) } )
 			);


### PR DESCRIPTION
This PR resolves [WP-109](https://appworld.atlassian.net/browse/WP-109).

## Description / Background Context

At the moment, when we import a Cover block, we see that the block does not import correctly as expected. The text typed into the Cover block does NOT appear after import. The expected behaviour should be that it appears and shows on the Cover block.

This PR implements a fix for this issue.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn install && yarn build`.
- Head over to `tastewp.com` [here](https://tastewp.com/create/NMS/8.0/6.7.0/convert-blocks-to-json/twentytwentythree?ni=true&origin=wp) and spin up a new WP instance.
- Now create a Cover block by typing `/cover` into the block editor (**make sure to put a text in it**) and publish the post.
- Locate the `Convert Blocks to JSON` icon and export the blocks into a JSON file.
- (**For Engineers**) - Go back to your local environment and import the JSON file. (**For QA**) please use the [test](https://aw-wp-env.com/wp-admin/) server and import the JSON file.
- Observe that the Cover block is now working correctly and the text that is typed within shows correctly.

---

<img width="927" height="719" alt="Screenshot 2026-02-17 at 08 48 12" src="https://github.com/user-attachments/assets/d31108fe-fcda-4af5-a60c-b1d4f79bbdb8" />

