### PR TITLE
Fix: Quote block import issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix: Import issues with `core/heading` block.
 * Fix: Import issues with `core/details` block.
 * Fix: Import issues with `core/pullquote` block.
+* Fix: Import issues with `core/quote` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 * Fix: Import issues with `core/heading` block.
 * Fix: Import issues with `core/details` block.
 * Fix: Import issues with `core/pullquote` block.
+* Fix: Import issues with `core/quote` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/src/filters.tsx
+++ b/src/filters.tsx
@@ -17,6 +17,7 @@ addFilter( 'cbtj.innerBlocks', 'cbtj', ( innerBlocks, block ) => {
 
 	switch ( block ) {
 		case 'core/list':
+		case 'core/quote':
 		case 'core/details':
 			blocks = innerBlocks.map( ( { name, attributes } ) =>
 				createBlock( name, { ...JSON.parse( attributes ) } )


### PR DESCRIPTION
This PR resolves [WP-98](https://appworld.atlassian.net/browse/WP-98).

## Description / Background Context

At the moment, when we import a Quote block, we see that the block does not import correctly as expected. The quote do NOT show after import. The expected behaviour should be that when the block is imported it shows correctly.

This PR implements a fix for this issue.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn install && yarn build`.
- Head over to `tastewp.com` [here](https://tastewp.com/create/NMS/8.0/6.7.0/convert-blocks-to-json/twentytwentythree?ni=true&origin=wp) and spin up a new WP instance.
- Now create a quote block (**make sure to put a quote within it**) and publish the post.
- Locate the `Convert Blocks to JSON` icon and export the blocks into a JSON file.
- (**For Engineers**) - Go back to your local environment and import the JSON file. (**For QA**) please use the [test](https://aw-wp-env.com/wp-admin/) server and import the JSON file.
- Observe that the Quote block is now working correctly and the quote is showing as expected.

<img width="1919" height="743" alt="image" src="https://github.com/user-attachments/assets/4d7f5904-32f8-4322-9c18-f4b96c30f35f" />
