### PR TITLE
Fix: Table block import issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix: Import issues with `core/details` block.
 * Fix: Import issues with `core/pullquote` block.
 * Fix: Import issues with `core/cover` block.
+* Fix: Import issues with `core/table` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/inc/Blocks/Table.php
+++ b/inc/Blocks/Table.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Table Block
+ *
+ * This class is responsible for customizing
+ * the Table block output.
+ *
+ * @package ConvertBlocksToJSON
+ */
+
+namespace ConvertBlocksToJSON\Blocks;
+
+use ConvertBlocksToJSON\Abstracts\Block;
+
+class Table extends Block {
+	/**
+	 * Import Block.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed[] $block Import Block.
+	 * @return mixed[]
+	 */
+	public function import_block( $block ): array {
+		//Bail out, if undefined OR not Table block.
+		if ( empty( $block['name'] ) || 'core/table' !== $block['name'] ) {
+			return $block;
+		}
+
+		// Decode attributes correctly.
+		$block['attributes'] = json_decode( $block['attributes'] ?? '{}', true );
+
+		// Get the block content.
+		$content = $block['attributes']['content'] ?? '';
+
+		// Set the body.
+		$block['attributes']['body'] = $this->get_table_body( $content );
+
+		error_log( wp_json_encode( $block['attributes']['body'] ) );
+
+		return [
+			'name'        => $block['name'] ?? '',
+			'attributes'  => wp_json_encode( $block['attributes'] ?? [] ),
+			'innerBlocks' => $block['innerBlocks'] ?? [],
+		];
+
+		return $block;
+	}
+
+	/**
+	 * Export Block
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed $block Export Block.
+	 * @return mixed[]
+	 */
+	public function export_block( $block ): array {
+		//Bail out, if undefined OR not Table block.
+		if ( empty( $block['name'] ) || 'core/table' !== $block['name'] ) {
+			return $block;
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Get Table body.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string $content Table markup or innerHTML.
+	 * @return mixed[]
+	 */
+	protected function get_table_body( $content ): array {
+		$tbody = $this->get_tag_content( $content, 'tbody' );
+
+		return array_map(
+			function ( $tr ) {
+				preg_match_all( '/<td>(.*?)<\/td>/', $tr, $matches );
+
+				$cells = array_map(
+					function ( $td ) {
+						return [
+							'content' => $td,
+							'tag'     => 'td',
+						];
+					},
+					$matches[0] ?? []
+				);
+
+				return [
+					'cells' => $cells,
+				];
+			},
+			$this->get_table_rows( $tbody )
+		);
+	}
+
+	/**
+	 * Get Table Rows
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string $content Table markup nested in `tbody`.
+	 * @return mixed[]
+	 */
+	protected function get_table_rows( $content ): array {
+		preg_match_all( '/<tr>(.*?)<\/tr>/', $content, $matches );
+
+		return $matches[0] ?? [];
+	}
+}

--- a/inc/Services/Blocks.php
+++ b/inc/Services/Blocks.php
@@ -16,6 +16,7 @@ use ConvertBlocksToJSON\Blocks\Lists;
 use ConvertBlocksToJSON\Blocks\ListItem;
 use ConvertBlocksToJSON\Blocks\Image;
 use ConvertBlocksToJSON\Blocks\Paragraph;
+use ConvertBlocksToJSON\Blocks\Table;
 
 use ConvertBlocksToJSON\Abstracts\Block;
 use ConvertBlocksToJSON\Abstracts\Service;
@@ -46,6 +47,7 @@ class Blocks extends Service implements Kernel {
 			ListItem::class,
 			Image::class,
 			Paragraph::class,
+			Table::class,
 		];
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 * Fix: Import issues with `core/details` block.
 * Fix: Import issues with `core/pullquote` block.
 * Fix: Import issues with `core/cover` block.
+* Fix: Import issues with `core/table` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/tests/unit/php/Services/BlocksTest.php
+++ b/tests/unit/php/Services/BlocksTest.php
@@ -14,6 +14,7 @@ use ConvertBlocksToJSON\Blocks\Lists;
 use ConvertBlocksToJSON\Blocks\ListItem;
 use ConvertBlocksToJSON\Blocks\Image;
 use ConvertBlocksToJSON\Blocks\Paragraph;
+use ConvertBlocksToJSON\Blocks\Table;
 
 /**
  * @covers \ConvertBlocksToJSON\Services\Blocks::__construct
@@ -43,6 +44,7 @@ class BlocksTest extends WPMockTestCase {
 				ListItem::class,
 				Image::class,
 				Paragraph::class,
+				Table::class,
 			],
 			$this->blocks->blocks
 		);
@@ -86,6 +88,7 @@ class BlocksTest extends WPMockTestCase {
 				ListItem::class,
 				Image::class,
 				Paragraph::class,
+				Table::class,
 			]
 		);
 


### PR DESCRIPTION
This PR resolves [WP-101](https://appworld.atlassian.net/browse/WP-101).

## Description / Background Context

At the moment, when we import a Table block, we see that the block does not import correctly as expected. The text typed into the Table block does NOT appear after import. The expected behaviour should be that it appears and shows on the Table block.

This PR implements a fix for this issue.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn install && yarn build`.
- Head over to `tastewp.com` [here](https://tastewp.com/create/NMS/8.0/6.7.0/convert-blocks-to-json/twentytwentythree?ni=true&origin=wp) and spin up a new WP instance.
- Now create a Table block by typing `/table` into the block editor (**make sure to put a text in the table cells**) and publish the post.
- Locate the `Convert Blocks to JSON` icon and export the blocks into a JSON file.
- (**For Engineers**) - Go back to your local environment and import the JSON file. (**For QA**) please use the [test](https://aw-wp-env.com/wp-admin/) server and import the JSON file.
- Observe that the Table block is now working correctly and the text that is typed within shows correctly.

---

<img width="909" height="421" alt="Screenshot 2026-02-17 at 10 47 59" src="https://github.com/user-attachments/assets/45f7955c-1783-4f43-85bc-9d8f197281f5" />
