### PR TITLE
Fix: Image and text issue under media block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix: Import issues with `core/cover` block.
 * Fix: Import issues with `core/table` block.
 * Fix: Import issues with `core/quote` block.
+* Fix: Import issues with `core/media-text` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/inc/Blocks/MediaText.php
+++ b/inc/Blocks/MediaText.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * MediaText Block
+ *
+ * This class is responsible for customizing
+ * the MediaText block output.
+ *
+ * @package ConvertBlocksToJSON
+ */
+
+namespace ConvertBlocksToJSON\Blocks;
+
+use ConvertBlocksToJSON\Abstracts\Block;
+
+class MediaText extends Block {
+	/**
+	 * Import Block.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed[] $block Import Block.
+	 * @return mixed[]
+	 */
+	public function import_block( $block ): array {
+		//Bail out, if undefined OR not MediaText block.
+		if ( empty( $block['name'] ) || 'core/media-text' !== $block['name'] ) {
+			return $block;
+		}
+
+		// Decode attributes correctly.
+		$block['attributes'] = json_decode( $block['attributes'] ?? '{}', true );
+
+		// Get the block attributes.
+		$attributes = $block['attributes'] ?? '';
+
+		// Ensure missing URL attribute is captured for image blocks.
+		preg_match( '/src="([^"]+)"/', $block['attributes']['content'] ?? '', $matches );
+		$block['attributes']['mediaUrl'] = esc_url( $matches[1] ?? '' );
+
+		// If it's not same site, get remote image.
+		if ( false === strpos( $block['attributes']['mediaUrl'] ?? '', home_url() ) ) {
+			$remote_image = $this->get_remote_image( $block['attributes']['mediaUrl'] ?? '' );
+
+			if ( ! is_wp_error( $remote_image ) ) {
+				$block['attributes']['mediaUrl'] = $remote_image;
+			}
+		}
+
+		// Set the mediaId, mediaLink & mediaType.
+		$block['attributes']['mediaId'] = $attributes['mediaId'] ;
+		$block['attributes']['mediaLink'] = $attributes['mediaLink'] ;
+		$block['attributes']['mediaType'] = $attributes['mediaType'] ;
+
+		return [
+			'name'        => $block['name'] ?? '',
+			'attributes'  => wp_json_encode( $block['attributes'] ?? [] ),
+			'innerBlocks' => $block['innerBlocks'] ?? [],
+		];
+
+		return $block;
+	}
+
+	/**
+	 * Export Block
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed $block Export Block.
+	 * @return mixed[]
+	 */
+	public function export_block( $block ): array {
+		//Bail out, if undefined OR not MediaText block.
+		if ( empty( $block['name'] ) || 'core/media-text' !== $block['name'] ) {
+			return $block;
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Import Image.
+	 *
+	 * This is specific to importing images from
+	 * an external or remote website.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string $image_url Image URL.
+	 * @return string|\WP_Error
+	 */
+	protected function get_remote_image( $image_url ) {
+		if ( ! function_exists( 'download_url' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		if ( ! function_exists( 'wp_handle_sideload' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		if ( ! function_exists( 'wp_generate_attachment_metadata' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/image.php';
+		}
+
+		// Download the file to a temporary location.
+		$tmp_file = download_url( sanitize_url( $image_url ) );
+
+		// Bail out, if wp_error.
+		if ( is_wp_error( $tmp_file ) ) {
+			error_log(
+				sprintf(
+					'Import error: %s, %s',
+					$tmp_file->get_error_message() ?? '',
+					$image_url
+				)
+			);
+
+			return $tmp_file;
+		}
+
+		// Get the filename + extension from the URL.
+		$url_filename = basename( parse_url( $image_url, PHP_URL_PATH ) );
+
+		// Build an array that resembles a PHP file upload.
+		$filetype = wp_check_filetype( $url_filename );
+
+		// Build an array that resembles a PHP file upload.
+		$file = [
+			'name'     => $url_filename,
+			'type'     => $filetype['type'] ?? 'application/octet-stream',
+			'tmp_name' => $tmp_file,
+			'error'    => 0,
+			'size'     => filesize( $tmp_file ),
+		];
+
+		// Let WordPress handle the sideload.
+		$overrides = [
+			'test_form'   => false,
+			'test_size'   => true,
+			'test_upload' => true,
+		];
+
+		$results = wp_handle_sideload( $file, $overrides );
+
+		// Bail out, if upload error.
+		if ( isset( $results['error'] ) ) {
+			@unlink( $tmp_file );
+			$error_message = sprintf( 'Import error: %s', $results['error'] ?? '' );
+			error_log( $error_message );
+
+			return new WP_Error( 'cbtj-import-error', $error_message );
+		}
+
+		// Now create attachment post for the image.
+		$attachment = [
+			'post_mime_type' => $results['type'],
+			'post_title'     => sanitize_file_name( pathinfo( $url_filename, PATHINFO_FILENAME ) ),
+			'post_content'   => '',
+			'post_status'    => 'inherit',
+		];
+
+		$attach_id = wp_insert_attachment( $attachment, $results['file'] );
+
+		// Bail out, if wp_error.
+		if ( is_wp_error( $attach_id ) ) {
+			return $attach_id;
+		}
+
+		// Generate attachment metadata.
+		$metadata = wp_generate_attachment_metadata( $attach_id, $results['file'] );
+		wp_update_attachment_metadata( $attach_id, $metadata );
+
+		return wp_get_attachment_url( $attach_id );
+	}
+}

--- a/inc/Blocks/MediaText.php
+++ b/inc/Blocks/MediaText.php
@@ -47,9 +47,9 @@ class MediaText extends Block {
 		}
 
 		// Set the mediaId, mediaLink & mediaType.
-		$block['attributes']['mediaId'] = $attributes['mediaId'] ;
-		$block['attributes']['mediaLink'] = $attributes['mediaLink'] ;
-		$block['attributes']['mediaType'] = $attributes['mediaType'] ;
+		$block['attributes']['mediaId']   = $attributes['mediaId'];
+		$block['attributes']['mediaLink'] = $attributes['mediaLink'];
+		$block['attributes']['mediaType'] = $attributes['mediaType'];
 
 		return [
 			'name'        => $block['name'] ?? '',

--- a/inc/Blocks/MediaText.php
+++ b/inc/Blocks/MediaText.php
@@ -63,7 +63,7 @@ class MediaText extends Block {
 	 * @return mixed[]
 	 */
 	public function export_block( $block ): array {
-		//Bail out, if undefined OR not MediaText block.
+		// Bail out, if undefined OR not MediaText block.
 		if ( empty( $block['name'] ) || 'core/media-text' !== $block['name'] ) {
 			return $block;
 		}

--- a/inc/Blocks/MediaText.php
+++ b/inc/Blocks/MediaText.php
@@ -30,8 +30,6 @@ class MediaText extends Block {
 		// Decode attributes correctly.
 		$block['attributes'] = json_decode( $block['attributes'] ?? '{}', true );
 
-		// Get the block attributes.
-		$attributes = $block['attributes'] ?? '';
 
 		// Ensure missing URL attribute is captured for image blocks.
 		preg_match( '/src="([^"]+)"/', $block['attributes']['content'] ?? '', $matches );

--- a/inc/Blocks/MediaText.php
+++ b/inc/Blocks/MediaText.php
@@ -22,7 +22,7 @@ class MediaText extends Block {
 	 * @return mixed[]
 	 */
 	public function import_block( $block ): array {
-		//Bail out, if undefined OR not MediaText block.
+		// Bail out, if undefined OR not MediaText block.
 		if ( empty( $block['name'] ) || 'core/media-text' !== $block['name'] ) {
 			return $block;
 		}

--- a/inc/Blocks/MediaText.php
+++ b/inc/Blocks/MediaText.php
@@ -44,10 +44,6 @@ class MediaText extends Block {
 			}
 		}
 
-		// Set the mediaId, mediaLink & mediaType.
-		$block['attributes']['mediaId']   = $attributes['mediaId'];
-		$block['attributes']['mediaLink'] = $attributes['mediaLink'];
-		$block['attributes']['mediaType'] = $attributes['mediaType'];
 
 		return [
 			'name'        => $block['name'] ?? '',

--- a/inc/Blocks/MediaText.php
+++ b/inc/Blocks/MediaText.php
@@ -30,7 +30,6 @@ class MediaText extends Block {
 		// Decode attributes correctly.
 		$block['attributes'] = json_decode( $block['attributes'] ?? '{}', true );
 
-
 		// Ensure missing URL attribute is captured for image blocks.
 		preg_match( '/src="([^"]+)"/', $block['attributes']['content'] ?? '', $matches );
 		$block['attributes']['mediaUrl'] = esc_url( $matches[1] ?? '' );
@@ -43,7 +42,6 @@ class MediaText extends Block {
 				$block['attributes']['mediaUrl'] = $remote_image;
 			}
 		}
-
 
 		return [
 			'name'        => $block['name'] ?? '',

--- a/inc/Services/Blocks.php
+++ b/inc/Services/Blocks.php
@@ -12,13 +12,13 @@ namespace ConvertBlocksToJSON\Services;
 
 use ConvertBlocksToJSON\Blocks\Details;
 use ConvertBlocksToJSON\Blocks\Heading;
+use ConvertBlocksToJSON\Blocks\Image;
 use ConvertBlocksToJSON\Blocks\Lists;
 use ConvertBlocksToJSON\Blocks\ListItem;
-use ConvertBlocksToJSON\Blocks\Image;
+use ConvertBlocksToJSON\Blocks\MediaText;
 use ConvertBlocksToJSON\Blocks\Paragraph;
 use ConvertBlocksToJSON\Blocks\Pullquote;
 use ConvertBlocksToJSON\Blocks\Table;
-
 use ConvertBlocksToJSON\Abstracts\Block;
 use ConvertBlocksToJSON\Abstracts\Service;
 use ConvertBlocksToJSON\Interfaces\Kernel;
@@ -44,9 +44,10 @@ class Blocks extends Service implements Kernel {
 		$this->blocks = [
 			Details::class,
 			Heading::class,
+			Image::class,
 			Lists::class,
 			ListItem::class,
-			Image::class,
+			MediaText::class,
 			Paragraph::class,
 			Pullquote::class,
 			Table::class,

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 * Fix: Import issues with `core/cover` block.
 * Fix: Import issues with `core/table` block.
 * Fix: Import issues with `core/quote` block.
+* Fix: Import issues with `core/media-text` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/src/filters.tsx
+++ b/src/filters.tsx
@@ -19,6 +19,7 @@ addFilter( 'cbtj.innerBlocks', 'cbtj', ( innerBlocks, block ) => {
 		case 'core/list':
 		case 'core/quote':
 		case 'core/details':
+		case 'core/media-text':
 		case 'core/cover':
 			blocks = innerBlocks.map( ( { name, attributes } ) =>
 				createBlock( name, { ...JSON.parse( attributes ) } )

--- a/tests/unit/php/Services/BlocksTest.php
+++ b/tests/unit/php/Services/BlocksTest.php
@@ -10,9 +10,10 @@ use ConvertBlocksToJSON\Services\Blocks;
 
 use ConvertBlocksToJSON\Blocks\Details;
 use ConvertBlocksToJSON\Blocks\Heading;
+use ConvertBlocksToJSON\Blocks\Image;
 use ConvertBlocksToJSON\Blocks\Lists;
 use ConvertBlocksToJSON\Blocks\ListItem;
-use ConvertBlocksToJSON\Blocks\Image;
+use ConvertBlocksToJSON\Blocks\MediaText;
 use ConvertBlocksToJSON\Blocks\Paragraph;
 use ConvertBlocksToJSON\Blocks\Pullquote;
 use ConvertBlocksToJSON\Blocks\Table;
@@ -41,9 +42,10 @@ class BlocksTest extends WPMockTestCase {
 			[
 				Details::class,
 				Heading::class,
+				Image::class,
 				Lists::class,
 				ListItem::class,
-				Image::class,
+				MediaText::class,
 				Paragraph::class,
 				Pullquote::class,
 				Table::class,
@@ -86,9 +88,10 @@ class BlocksTest extends WPMockTestCase {
 			[
 				Details::class,
 				Heading::class,
+				Image::class,
 				Lists::class,
 				ListItem::class,
-				Image::class,
+				MediaText::class,
 				Paragraph::class,
 				Pullquote::class,
 				Table::class,


### PR DESCRIPTION
This PR resolves [WP-105](https://appworld.atlassian.net/browse/WP-105).

## Description / Background Context

At the moment, when we import a Media & text block, we see that the block does not import correctly as expected. The text typed in the content section and the image does NOT appear after import. The expected behaviour should be that after import both the image and text should display.

This PR implements a fix for this issue.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn install && yarn build`.
- Head over to `tastewp.com` [here](https://tastewp.com/create/NMS/8.0/6.7.0/convert-blocks-to-json/twentytwentythree?ni=true&origin=wp) and spin up a new WP instance.
- Now create a Media & text block by typing `/media` into the block editor (**make sure to put a text in the content section and upload a file in the media section**) and publish the post.
- Locate the `Convert Blocks to JSON` icon and export the blocks into a JSON file.
- (**For Engineers**) - Go back to your local environment and import the JSON file. (**For QA**) please use the [test](https://aw-wp-env.com/wp-admin/) server and import the JSON file.
- Observe that the Media & Text block is now working correctly and both media uploaded and content typed are displaying.

---

<img width="1919" height="765" alt="Screenshot 2026-02-18 125937" src="https://github.com/user-attachments/assets/288f7d00-7b76-48d0-98ed-848506390131" />

