### PR TITLE
Fix: Gallery block import issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fix: Import issues with `core/table` block.
 * Fix: Import issues with `core/quote` block.
 * Fix: Import issues with `core/media-text` block.
+* Fix: Import issues with `core/gallery` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 * Fix: Import issues with `core/table` block.
 * Fix: Import issues with `core/quote` block.
 * Fix: Import issues with `core/media-text` block.
+* Fix: Import issues with `core/gallery` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/src/filters.tsx
+++ b/src/filters.tsx
@@ -20,6 +20,7 @@ addFilter( 'cbtj.innerBlocks', 'cbtj', ( innerBlocks, block ) => {
 		case 'core/quote':
 		case 'core/details':
 		case 'core/media-text':
+		case 'core/gallery':
 		case 'core/cover':
 			blocks = innerBlocks.map( ( { name, attributes } ) =>
 				createBlock( name, { ...JSON.parse( attributes ) } )


### PR DESCRIPTION
This PR resolves [WP-106](https://appworld.atlassian.net/browse/WP-106).

## Description / Background Context

At the moment, when we import a Gallery block, we see that the block does not import correctly as expected. The images added to the gallery does NOT appear after import. The expected behaviour should be that after import, all images added to the block should display.

This PR implements a fix for this issue.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn install && yarn build`.
- Head over to `tastewp.com` [here](https://tastewp.com/create/NMS/8.0/6.7.0/convert-blocks-to-json/twentytwentythree?ni=true&origin=wp) and spin up a new WP instance.
- Now create a Gallery block by typing `/gallery` into the block editor (**make sure to insert at least one image **) and publish the post.
- Locate the `Convert Blocks to JSON` icon and export the blocks into a JSON file.
- (**For Engineers**) - Go back to your local environment and import the JSON file. (**For QA**) please use the [test](https://aw-wp-env.com/wp-admin/) server and import the JSON file.
- Observe that the Gallery block is now working correctly and all images uploaded are displaying.

---

<img width="1809" height="760" alt="Screenshot 2026-02-19 095252" src="https://github.com/user-attachments/assets/f4c4962a-3e58-4a20-bb0f-bec68a1d6435" />


