### PR TITLE
Fix: Audio issue under media block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fix: Import issues with `core/quote` block.
 * Fix: Import issues with `core/media-text` block.
 * Fix: Import issues with `core/gallery` block.
+* Fix: Import issues with `core/audio` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/inc/Abstracts/Block.php
+++ b/inc/Abstracts/Block.php
@@ -117,6 +117,10 @@ abstract class Block {
 			require_once ABSPATH . 'wp-admin/includes/image.php';
 		}
 
+		if ( ! function_exists( 'wp_read_audio_metadata' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/media.php';
+		}
+
 		// Download the file to a temporary location.
 		$tmp_file = download_url( sanitize_url( $file_url ) );
 

--- a/inc/Abstracts/Block.php
+++ b/inc/Abstracts/Block.php
@@ -10,6 +10,9 @@
 
 namespace ConvertBlocksToJSON\Abstracts;
 
+use WP_Error;
+use Throwable;
+
 /**
  * Block class.
  */
@@ -120,7 +123,7 @@ abstract class Block {
 		// Download the file to a temporary location.
 		$tmp_file = download_url( sanitize_url( $file_url ) );
 
-		// Bail out, if wp_error.
+		// Bail out, if is WP_Error.
 		if ( is_wp_error( $tmp_file ) ) {
 			error_log(
 				sprintf(
@@ -136,26 +139,24 @@ abstract class Block {
 		// Get the filename + extension from the URL.
 		$url_filename = basename( parse_url( $file_url, PHP_URL_PATH ) );
 
-		// Build an array that resembles a PHP file upload.
+		// Get the file type.
 		$filetype = wp_check_filetype( $url_filename );
 
-		// Build an array that resembles a PHP file upload.
-		$file = [
-			'name'     => $url_filename,
-			'type'     => $filetype['type'] ?? 'application/octet-stream',
-			'tmp_name' => $tmp_file,
-			'error'    => 0,
-			'size'     => filesize( $tmp_file ),
-		];
-
-		// Let WordPress handle the sideload.
-		$overrides = [
-			'test_form'   => false,
-			'test_size'   => true,
-			'test_upload' => true,
-		];
-
-		$results = wp_handle_sideload( $file, $overrides );
+		// Let WordPress handle the upload correctly.
+		$results = wp_handle_sideload(
+			[
+				'name'     => $url_filename,
+				'type'     => $filetype['type'] ?? 'application/octet-stream',
+				'tmp_name' => $tmp_file,
+				'error'    => 0,
+				'size'     => filesize( $tmp_file ),
+			],
+			[
+				'test_form'   => false,
+				'test_size'   => true,
+				'test_upload' => true,
+			]
+		);
 
 		// Bail out, if upload error.
 		if ( isset( $results['error'] ) ) {
@@ -166,23 +167,27 @@ abstract class Block {
 			return new WP_Error( 'cbtj-import-error', $error_message );
 		}
 
+		// The imported file url path.
+		$imported_file_url = $results['file'] ?? '';
+
 		// Now create attachment post for the image.
-		$attachment = [
-			'post_mime_type' => $results['type'],
-			'post_title'     => sanitize_file_name( pathinfo( $url_filename, PATHINFO_FILENAME ) ),
-			'post_content'   => '',
-			'post_status'    => 'inherit',
-		];
+		$attach_id = wp_insert_attachment(
+			[
+				'post_mime_type' => $results['type'] ?? '',
+				'post_title'     => sanitize_file_name( pathinfo( $url_filename, PATHINFO_FILENAME ) ),
+				'post_content'   => '',
+				'post_status'    => 'inherit',
+			],
+			$imported_file_url
+		);
 
-		$attach_id = wp_insert_attachment( $attachment, $results['file'] );
-
-		// Bail out, if wp_error.
+		// Bail out, if is WP_Error.
 		if ( is_wp_error( $attach_id ) ) {
 			return $attach_id;
 		}
 
 		try {
-			$metadata = wp_generate_attachment_metadata( $attach_id, $results['file'] );
+			$metadata = wp_generate_attachment_metadata( $attach_id, $imported_file_url );
 			wp_update_attachment_metadata( $attach_id, $metadata );
 		} catch ( Throwable $e ) {
 			error_log( 'Fatal caught: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() );

--- a/inc/Abstracts/Block.php
+++ b/inc/Abstracts/Block.php
@@ -97,14 +97,15 @@ abstract class Block {
 	}
 
 	/**
-	 * Get File Url.
+	 * Get Remote File.
 	 *
 	 * This is specific to importing files from
-	 * an external or remote website.
+	 * an external or remote website. Just to clarify,
+	 * file could be an image, audio or video.
 	 *
 	 * @since 1.3.0
 	 *
-	 * @param string $file_url Image URL.
+	 * @param string $file_url File URL.
 	 * @return string|\WP_Error
 	 */
 	protected function get_remote_file( $file_url ) {

--- a/inc/Abstracts/Block.php
+++ b/inc/Abstracts/Block.php
@@ -187,7 +187,7 @@ abstract class Block {
 		} catch ( Throwable $e ) {
 			error_log( 'Fatal caught: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() );
 			
-			return new \WP_Error( 'cbtj-metadata-error', $e->getMessage() );
+			return new WP_Error( 'cbtj-metadata-error', $e->getMessage() );
 		}
 
 		return wp_get_attachment_url( $attach_id );

--- a/inc/Abstracts/Block.php
+++ b/inc/Abstracts/Block.php
@@ -143,15 +143,18 @@ abstract class Block {
 		// Get the file type.
 		$filetype = wp_check_filetype( $url_filename );
 
+		// Build an array that resembles a PHP file upload.
+		$file = [
+			'name'     => $url_filename,
+			'type'     => $filetype['type'] ?? 'application/octet-stream',
+			'tmp_name' => $tmp_file,
+			'error'    => 0,
+			'size'     => filesize( $tmp_file ),
+		];
+
 		// Let WordPress handle the upload correctly.
 		$results = wp_handle_sideload(
-			[
-				'name'     => $url_filename,
-				'type'     => $filetype['type'] ?? 'application/octet-stream',
-				'tmp_name' => $tmp_file,
-				'error'    => 0,
-				'size'     => filesize( $tmp_file ),
-			],
+			$file,
 			[
 				'test_form'   => false,
 				'test_size'   => true,

--- a/inc/Abstracts/Block.php
+++ b/inc/Abstracts/Block.php
@@ -104,7 +104,7 @@ abstract class Block {
 	 * @param string $file_url Image URL.
 	 * @return string|\WP_Error
 	 */
-	public function get_remote_file( $file_url ) {
+	protected function get_remote_file( $file_url ) {
 		if ( ! function_exists( 'download_url' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';
 		}

--- a/inc/Abstracts/Block.php
+++ b/inc/Abstracts/Block.php
@@ -186,6 +186,7 @@ abstract class Block {
 			wp_update_attachment_metadata( $attach_id, $metadata );
 		} catch ( Throwable $e ) {
 			error_log( 'Fatal caught: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() );
+			
 			return new \WP_Error( 'cbtj-metadata-error', $e->getMessage() );
 		}
 

--- a/inc/Abstracts/Block.php
+++ b/inc/Abstracts/Block.php
@@ -92,4 +92,103 @@ abstract class Block {
 
 		return $match[1] ?? '';
 	}
+
+	/**
+	 * Get File Url.
+	 *
+	 * This is specific to importing files from
+	 * an external or remote website.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string $file_url Image URL.
+	 * @return string|\WP_Error
+	 */
+	public function get_remote_file( $file_url ) {
+		if ( ! function_exists( 'download_url' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		if ( ! function_exists( 'wp_handle_sideload' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		if ( ! function_exists( 'wp_generate_attachment_metadata' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/image.php';
+		}
+
+		// Download the file to a temporary location.
+		$tmp_file = download_url( sanitize_url( $file_url ) );
+
+		// Bail out, if wp_error.
+		if ( is_wp_error( $tmp_file ) ) {
+			error_log(
+				sprintf(
+					'Import error: %s, %s',
+					$tmp_file->get_error_message() ?? '',
+					$file_url
+				)
+			);
+
+			return $tmp_file;
+		}
+
+		// Get the filename + extension from the URL.
+		$url_filename = basename( parse_url( $file_url, PHP_URL_PATH ) );
+
+		// Build an array that resembles a PHP file upload.
+		$filetype = wp_check_filetype( $url_filename );
+
+		// Build an array that resembles a PHP file upload.
+		$file = [
+			'name'     => $url_filename,
+			'type'     => $filetype['type'] ?? 'application/octet-stream',
+			'tmp_name' => $tmp_file,
+			'error'    => 0,
+			'size'     => filesize( $tmp_file ),
+		];
+
+		// Let WordPress handle the sideload.
+		$overrides = [
+			'test_form'   => false,
+			'test_size'   => true,
+			'test_upload' => true,
+		];
+
+		$results = wp_handle_sideload( $file, $overrides );
+
+		// Bail out, if upload error.
+		if ( isset( $results['error'] ) ) {
+			@unlink( $tmp_file );
+			$error_message = sprintf( 'Import error: %s', $results['error'] ?? '' );
+			error_log( $error_message );
+
+			return new WP_Error( 'cbtj-import-error', $error_message );
+		}
+
+		// Now create attachment post for the image.
+		$attachment = [
+			'post_mime_type' => $results['type'],
+			'post_title'     => sanitize_file_name( pathinfo( $url_filename, PATHINFO_FILENAME ) ),
+			'post_content'   => '',
+			'post_status'    => 'inherit',
+		];
+
+		$attach_id = wp_insert_attachment( $attachment, $results['file'] );
+
+		// Bail out, if wp_error.
+		if ( is_wp_error( $attach_id ) ) {
+			return $attach_id;
+		}
+
+		try {
+			$metadata = wp_generate_attachment_metadata( $attach_id, $results['file'] );
+			wp_update_attachment_metadata( $attach_id, $metadata );
+		} catch ( \Throwable $e ) {
+			error_log( 'Fatal caught: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() );
+			return new \WP_Error( 'cbtj-metadata-error', $e->getMessage() );
+		}
+
+		return wp_get_attachment_url( $attach_id );
+	}
 }

--- a/inc/Abstracts/Block.php
+++ b/inc/Abstracts/Block.php
@@ -186,7 +186,7 @@ abstract class Block {
 			wp_update_attachment_metadata( $attach_id, $metadata );
 		} catch ( Throwable $e ) {
 			error_log( 'Fatal caught: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() );
-			
+
 			return new WP_Error( 'cbtj-metadata-error', $e->getMessage() );
 		}
 

--- a/inc/Abstracts/Block.php
+++ b/inc/Abstracts/Block.php
@@ -105,11 +105,7 @@ abstract class Block {
 	 * @return string|\WP_Error
 	 */
 	protected function get_remote_file( $file_url ) {
-		if ( ! function_exists( 'download_url' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-		}
-
-		if ( ! function_exists( 'wp_handle_sideload' ) ) {
+		if ( ! function_exists( 'download_url' ) || ! function_exists( 'wp_handle_sideload' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';
 		}
 

--- a/inc/Abstracts/Block.php
+++ b/inc/Abstracts/Block.php
@@ -184,7 +184,7 @@ abstract class Block {
 		try {
 			$metadata = wp_generate_attachment_metadata( $attach_id, $results['file'] );
 			wp_update_attachment_metadata( $attach_id, $metadata );
-		} catch ( \Throwable $e ) {
+		} catch ( Throwable $e ) {
 			error_log( 'Fatal caught: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() );
 			return new \WP_Error( 'cbtj-metadata-error', $e->getMessage() );
 		}

--- a/inc/Blocks/Audio.php
+++ b/inc/Blocks/Audio.php
@@ -44,7 +44,7 @@ class Audio extends Block {
 		}
 
 		// Re-encode attributes correctly.
-		$block['attributes'] = wp_json_encode( $block['attributes'] );
+		$block['attributes'] = wp_json_encode( $block['attributes'] ?? [] );
 
 		return $block;
 	}

--- a/inc/Blocks/Audio.php
+++ b/inc/Blocks/Audio.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Audio Block.
+ *
+ * This class is responsible for customizing
+ * the Audio block output.
+ *
+ * @package ConvertBlocksToJSON
+ */
+
+namespace ConvertBlocksToJSON\Blocks;
+
+use ConvertBlocksToJSON\Abstracts\Block;
+
+class Audio extends Block {
+	/**
+	 * Import Block.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed[] $block Import Block.
+	 * @return mixed[]
+	 */
+	public function import_block( $block ): array {
+		// Bail out, if undefined OR not Audio block.
+		if ( empty( $block['name'] ) || 'core/audio' !== $block['name'] ) {
+			return $block;
+		}
+
+		// Decode attributes correctly.
+		$block['attributes'] = json_decode( $block['attributes'] ?? '', true );
+
+		// Ensure missing SRC attribute is captured for audio blocks.
+		preg_match( '/src="([^"]+)"/', $block['attributes']['content'] ?? '', $matches );
+		$block['attributes']['src'] = esc_url( $matches[1] ?? '' );
+
+		// If it's not same site, get remote file.
+		if ( false === strpos( $block['attributes']['src'] ?? '', home_url() ) ) {
+			$remote_file = $this->get_remote_file( $block['attributes']['src'] ?? '' );
+
+			if ( ! is_wp_error( $remote_file ) ) {
+				$block['attributes']['src'] = $remote_file;
+			}
+		}
+
+		// Re-encode attributes correctly.
+		$block['attributes'] = wp_json_encode( $block['attributes'] );
+
+		return $block;
+	}
+
+	/**
+	 * Export Block.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param mixed[] $block Export Block.
+	 * @return mixed[]
+	 */
+	public function export_block( $block ): array {
+		// Bail out, if undefined OR not Audio block.
+		if ( empty( $block['name'] ) || 'core/audio' !== $block['name'] ) {
+			return $block;
+		}
+
+		return $block;
+	}
+}

--- a/inc/Blocks/Image.php
+++ b/inc/Blocks/Image.php
@@ -36,7 +36,7 @@ class Image extends Block {
 
 		// If it's not same site, get remote image.
 		if ( false === strpos( $block['attributes']['url'] ?? '', home_url() ) ) {
-			$remote_image = $this->get_remote_image( $block['attributes']['url'] ?? '' );
+			$remote_image = $this->get_remote_file( $block['attributes']['url'] ?? '' );
 
 			if ( ! is_wp_error( $remote_image ) ) {
 				$block['attributes']['url'] = $remote_image;
@@ -64,100 +64,5 @@ class Image extends Block {
 		}
 
 		return $block;
-	}
-
-	/**
-	 * Import Image.
-	 *
-	 * This is specific to importing images from
-	 * an external or remote website.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @param string $image_url Image URL.
-	 * @return string|\WP_Error
-	 */
-	protected function get_remote_image( $image_url ) {
-		if ( ! function_exists( 'download_url' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-		}
-
-		if ( ! function_exists( 'wp_handle_sideload' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-		}
-
-		if ( ! function_exists( 'wp_generate_attachment_metadata' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/image.php';
-		}
-
-		// Download the file to a temporary location.
-		$tmp_file = download_url( sanitize_url( $image_url ) );
-
-		// Bail out, if wp_error.
-		if ( is_wp_error( $tmp_file ) ) {
-			error_log(
-				sprintf(
-					'Import error: %s, %s',
-					$tmp_file->get_error_message() ?? '',
-					$image_url
-				)
-			);
-
-			return $tmp_file;
-		}
-
-		// Get the filename + extension from the URL.
-		$url_filename = basename( parse_url( $image_url, PHP_URL_PATH ) );
-
-		// Build an array that resembles a PHP file upload.
-		$filetype = wp_check_filetype( $url_filename );
-
-		// Build an array that resembles a PHP file upload.
-		$file = [
-			'name'     => $url_filename,
-			'type'     => $filetype['type'] ?? 'application/octet-stream',
-			'tmp_name' => $tmp_file,
-			'error'    => 0,
-			'size'     => filesize( $tmp_file ),
-		];
-
-		// Let WordPress handle the sideload.
-		$overrides = [
-			'test_form'   => false,
-			'test_size'   => true,
-			'test_upload' => true,
-		];
-
-		$results = wp_handle_sideload( $file, $overrides );
-
-		// Bail out, if upload error.
-		if ( isset( $results['error'] ) ) {
-			@unlink( $tmp_file );
-			$error_message = sprintf( 'Import error: %s', $results['error'] ?? '' );
-			error_log( $error_message );
-
-			return new WP_Error( 'cbtj-import-error', $error_message );
-		}
-
-		// Now create attachment post for the image.
-		$attachment = [
-			'post_mime_type' => $results['type'],
-			'post_title'     => sanitize_file_name( pathinfo( $url_filename, PATHINFO_FILENAME ) ),
-			'post_content'   => '',
-			'post_status'    => 'inherit',
-		];
-
-		$attach_id = wp_insert_attachment( $attachment, $results['file'] );
-
-		// Bail out, if wp_error.
-		if ( is_wp_error( $attach_id ) ) {
-			return $attach_id;
-		}
-
-		// Generate attachment metadata.
-		$metadata = wp_generate_attachment_metadata( $attach_id, $results['file'] );
-		wp_update_attachment_metadata( $attach_id, $metadata );
-
-		return wp_get_attachment_url( $attach_id );
 	}
 }

--- a/inc/Blocks/MediaText.php
+++ b/inc/Blocks/MediaText.php
@@ -36,7 +36,7 @@ class MediaText extends Block {
 
 		// If it's not same site, get remote image.
 		if ( false === strpos( $block['attributes']['mediaUrl'] ?? '', home_url() ) ) {
-			$remote_image = $this->get_remote_image( $block['attributes']['mediaUrl'] ?? '' );
+			$remote_image = $this->get_remote_file( $block['attributes']['mediaUrl'] ?? '' );
 
 			if ( ! is_wp_error( $remote_image ) ) {
 				$block['attributes']['mediaUrl'] = $remote_image;
@@ -67,100 +67,5 @@ class MediaText extends Block {
 		}
 
 		return $block;
-	}
-
-	/**
-	 * Import Image.
-	 *
-	 * This is specific to importing images from
-	 * an external or remote website.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @param string $image_url Image URL.
-	 * @return string|\WP_Error
-	 */
-	protected function get_remote_image( $image_url ) {
-		if ( ! function_exists( 'download_url' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-		}
-
-		if ( ! function_exists( 'wp_handle_sideload' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-		}
-
-		if ( ! function_exists( 'wp_generate_attachment_metadata' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/image.php';
-		}
-
-		// Download the file to a temporary location.
-		$tmp_file = download_url( sanitize_url( $image_url ) );
-
-		// Bail out, if wp_error.
-		if ( is_wp_error( $tmp_file ) ) {
-			error_log(
-				sprintf(
-					'Import error: %s, %s',
-					$tmp_file->get_error_message() ?? '',
-					$image_url
-				)
-			);
-
-			return $tmp_file;
-		}
-
-		// Get the filename + extension from the URL.
-		$url_filename = basename( parse_url( $image_url, PHP_URL_PATH ) );
-
-		// Build an array that resembles a PHP file upload.
-		$filetype = wp_check_filetype( $url_filename );
-
-		// Build an array that resembles a PHP file upload.
-		$file = [
-			'name'     => $url_filename,
-			'type'     => $filetype['type'] ?? 'application/octet-stream',
-			'tmp_name' => $tmp_file,
-			'error'    => 0,
-			'size'     => filesize( $tmp_file ),
-		];
-
-		// Let WordPress handle the sideload.
-		$overrides = [
-			'test_form'   => false,
-			'test_size'   => true,
-			'test_upload' => true,
-		];
-
-		$results = wp_handle_sideload( $file, $overrides );
-
-		// Bail out, if upload error.
-		if ( isset( $results['error'] ) ) {
-			@unlink( $tmp_file );
-			$error_message = sprintf( 'Import error: %s', $results['error'] ?? '' );
-			error_log( $error_message );
-
-			return new WP_Error( 'cbtj-import-error', $error_message );
-		}
-
-		// Now create attachment post for the image.
-		$attachment = [
-			'post_mime_type' => $results['type'],
-			'post_title'     => sanitize_file_name( pathinfo( $url_filename, PATHINFO_FILENAME ) ),
-			'post_content'   => '',
-			'post_status'    => 'inherit',
-		];
-
-		$attach_id = wp_insert_attachment( $attachment, $results['file'] );
-
-		// Bail out, if wp_error.
-		if ( is_wp_error( $attach_id ) ) {
-			return $attach_id;
-		}
-
-		// Generate attachment metadata.
-		$metadata = wp_generate_attachment_metadata( $attach_id, $results['file'] );
-		wp_update_attachment_metadata( $attach_id, $metadata );
-
-		return wp_get_attachment_url( $attach_id );
 	}
 }

--- a/inc/Services/Blocks.php
+++ b/inc/Services/Blocks.php
@@ -10,6 +10,7 @@
 
 namespace ConvertBlocksToJSON\Services;
 
+use ConvertBlocksToJSON\Blocks\Audio;
 use ConvertBlocksToJSON\Blocks\Details;
 use ConvertBlocksToJSON\Blocks\Heading;
 use ConvertBlocksToJSON\Blocks\Image;
@@ -42,6 +43,7 @@ class Blocks extends Service implements Kernel {
 	 */
 	public function __construct() {
 		$this->blocks = [
+			Audio::class,
 			Details::class,
 			Heading::class,
 			Image::class,

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 * Fix: Import issues with `core/quote` block.
 * Fix: Import issues with `core/media-text` block.
 * Fix: Import issues with `core/gallery` block.
+* Fix: Import issues with `core/audio` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/tests/unit/php/Blocks/ImageTest.php
+++ b/tests/unit/php/Blocks/ImageTest.php
@@ -96,7 +96,7 @@ class ImageTest extends WPMockTestCase {
 		WP_Mock::userFunction( 'is_wp_error' )
 			->andReturn( true );
 
-		$image->shouldReceive( 'get_remote_image' )
+		$image->shouldReceive( 'get_remote_file' )
 			->with( 'https://www.johndoe.com/wp-content/image.jpg' )
 			->andReturn( $wp_error );
 
@@ -128,7 +128,7 @@ class ImageTest extends WPMockTestCase {
 		WP_Mock::userFunction( 'is_wp_error' )
 			->andReturn( false );
 
-		$image->shouldReceive( 'get_remote_image' )
+		$image->shouldReceive( 'get_remote_file' )
 			->with( 'https://www.johndoe.com/wp-content/image.jpg' )
 			->andReturn( 'https://www.example.com/wp-content/imported-image.jpg' );
 

--- a/tests/unit/php/Services/BlocksTest.php
+++ b/tests/unit/php/Services/BlocksTest.php
@@ -8,6 +8,7 @@ use Badasswp\WPMockTC\WPMockTestCase;
 use ConvertBlocksToJSON\Abstracts\Block;
 use ConvertBlocksToJSON\Services\Blocks;
 
+use ConvertBlocksToJSON\Blocks\Audio;
 use ConvertBlocksToJSON\Blocks\Details;
 use ConvertBlocksToJSON\Blocks\Heading;
 use ConvertBlocksToJSON\Blocks\Image;
@@ -40,6 +41,7 @@ class BlocksTest extends WPMockTestCase {
 	public function test_class_properties_are_defined_by_default() {
 		$this->assertSame(
 			[
+				Audio::class,
 				Details::class,
 				Heading::class,
 				Image::class,
@@ -86,6 +88,7 @@ class BlocksTest extends WPMockTestCase {
 		WP_Mock::expectFilter(
 			'cbtj_blocks',
 			[
+				Audio::class,
 				Details::class,
 				Heading::class,
 				Image::class,


### PR DESCRIPTION
This PR resolves [WP-107](https://appworld.atlassian.net/browse/WP-107).

## Description / Background Context

At the moment, when we import an Audio block, we see that the block does not import correctly as expected. The audio does NOT appear after import. The expected behaviour should be that after import, audio should display.

This PR implements a fix for this issue.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn install && yarn build`.
- Head over to `tastewp.com` [here](https://tastewp.com/create/NMS/8.0/6.7.0/convert-blocks-to-json/twentytwentythree?ni=true&origin=wp) and spin up a new WP instance.
- Now create an Audio block by typing `/audio` into the block editor (**make sure to insert an audio **) and publish the post.
- Locate the `Convert Blocks to JSON` icon and export the blocks into a JSON file.
- (**For Engineers**) - Go back to your local environment and import the JSON file. (**For QA**) please use the [test](https://aw-wp-env.com/wp-admin/) server and import the JSON file.
- Observe that the Audio block is now working correctly and the audio is displaying.

---
<img width="1918" height="780" alt="Screenshot 2026-02-19 155613" src="https://github.com/user-attachments/assets/60b6a473-7c1d-4341-a918-77aaae59a426" />