### PR TITLE
Fix: Classic block import issues

### DIFF
--- a/inc/Blocks/Freeform.php
+++ b/inc/Blocks/Freeform.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Freeform Block.
+ *
+ * This class is responsible for customizing
+ * the Freeform block output.
+ *
+ * @package ConvertBlocksToJSON
+ */
+
+namespace ConvertBlocksToJSON\Blocks;
+
+use ConvertBlocksToJSON\Abstracts\Block;
+
+class Freeform extends Block {
+	/**
+	 * Import Block.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed[] $block Import Block.
+	 * @return mixed[]
+	 */
+	public function import_block( $block ): array {
+		// Bail out, if undefined OR not Freeform block.
+		if ( empty( $block['name'] ) || 'core/freeform' !== $block['name'] ) {
+			return $block;
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Export Block.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed $block Export Block.
+	 * @return mixed[]
+	 */
+	public function export_block( $block ): array {
+		// Treat as Freeform block.
+		if ( empty( $block['name'] ) && ! empty ( $block['content'] ) ) {
+			$block['name'] = 'core/freeform';
+		}
+
+		return $block;
+	}
+}

--- a/inc/Blocks/Freeform.php
+++ b/inc/Blocks/Freeform.php
@@ -40,7 +40,7 @@ class Freeform extends Block {
 	 */
 	public function export_block( $block ): array {
 		// Treat as Freeform block.
-		if ( empty( $block['name'] ) && ! empty ( $block['content'] ) ) {
+		if ( empty( $block['name'] ) && ! empty( $block['content'] ) ) {
 			$block['name'] = 'core/freeform';
 		}
 

--- a/inc/Services/Blocks.php
+++ b/inc/Services/Blocks.php
@@ -11,6 +11,7 @@
 namespace ConvertBlocksToJSON\Services;
 
 use ConvertBlocksToJSON\Blocks\Details;
+use ConvertBlocksToJSON\Blocks\Freeform;
 use ConvertBlocksToJSON\Blocks\Heading;
 use ConvertBlocksToJSON\Blocks\Image;
 use ConvertBlocksToJSON\Blocks\Lists;
@@ -43,6 +44,7 @@ class Blocks extends Service implements Kernel {
 	public function __construct() {
 		$this->blocks = [
 			Details::class,
+			Freeform::class,
 			Heading::class,
 			Image::class,
 			Lists::class,

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -16,7 +16,7 @@ import { store as editorStore } from '@wordpress/editor';
  * @return {Promise<any[]>} Blocks.
  */
 export const getBlocks = async (): Promise< any[] > => {
-	const postID = select( editorStore ).getCurrentPostId();
+	const postID = ( select( editorStore ) as any ).getCurrentPostId();
 
 	return await apiFetch( {
 		path: `/cbtj/v1/${ postID }`,

--- a/tests/unit/php/Services/BlocksTest.php
+++ b/tests/unit/php/Services/BlocksTest.php
@@ -9,6 +9,7 @@ use ConvertBlocksToJSON\Abstracts\Block;
 use ConvertBlocksToJSON\Services\Blocks;
 
 use ConvertBlocksToJSON\Blocks\Details;
+use ConvertBlocksToJSON\Blocks\Freeform;
 use ConvertBlocksToJSON\Blocks\Heading;
 use ConvertBlocksToJSON\Blocks\Image;
 use ConvertBlocksToJSON\Blocks\Lists;
@@ -41,6 +42,7 @@ class BlocksTest extends WPMockTestCase {
 		$this->assertSame(
 			[
 				Details::class,
+				Freeform::class,
 				Heading::class,
 				Image::class,
 				Lists::class,
@@ -87,6 +89,7 @@ class BlocksTest extends WPMockTestCase {
 			'cbtj_blocks',
 			[
 				Details::class,
+				Freeform::class,
 				Heading::class,
 				Image::class,
 				Lists::class,


### PR DESCRIPTION
This PR resolves [WP-104](https://appworld.atlassian.net/browse/WP-104).

## Description / Background Context

At the moment, when we import a Classic block, we see that the block does not import correctly as expected. The text typed into the Classic block does NOT appear after import. The expected behaviour should be that it appears and shows on the Classic block.

This PR implements a fix for this issue.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn install && yarn build`.
- (**For Engineers**), please use your local environment, (**For QA**) use the [test](https://aw-wp-env.com/wp-admin/) server.
- Create a Classic block by typing `/classic` into the block editor (**make sure to put a text in it**) and publish the post.
- Locate the `Convert Blocks to JSON` icon and export the blocks into a JSON file.
- **Using the same environment**, please import the JSON file.
- Observe that the Classic block is now working correctly and the text that is typed within shows correctly.

---

<img width="592" height="285" alt="Screenshot 2026-02-20 at 05 17 43" src="https://github.com/user-attachments/assets/8cf5dc00-26ef-4d27-92cd-ded4f9420bd8" />
