### PR TITLE
Test: Freeform block

### DIFF
--- a/tests/unit/php/Blocks/FreeformTest.php
+++ b/tests/unit/php/Blocks/FreeformTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace ConvertBlocksToJSON\Tests\Blocks;
+
+use WP_Mock;
+use Mockery;
+use ConvertBlocksToJSON\Blocks\Freeform;
+use Badasswp\WPMockTC\WPMockTestCase;
+
+/**
+ * @covers \ConvertBlocksToJSON\Blocks\Freeform::import_block
+ * @covers \ConvertBlocksToJSON\Blocks\Freeform::export_block
+ */
+class FreeformTest extends WPMockTestCase {
+	public Freeform $freeform;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->freeform = new Freeform();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+	}
+
+	public function test_import_block_returns_default_block_if_name_is_undefined() {
+		$block = $this->freeform->import_block(
+			[
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_import_block_returns_default_block_if_block_is_not_freeform() {
+		$block = $this->freeform->import_block(
+			[
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_import_block_returns_same_block_if_it_is_a_freeform() {
+		$block = $this->freeform->import_block(
+			[
+				'name'        => 'core/freeform',
+				'attributes'  => '{"content":"<h1>This is heading<\/h1><p>This is a paragraph...<\/p>"}',
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'        => 'core/freeform',
+				'attributes'  => '{"content":"<h1>This is heading<\/h1><p>This is a paragraph...<\/p>"}',
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_default_block_if_name_is_undefined_and_content_is_empty() {
+		$block = $this->freeform->export_block(
+			[
+				'content'     => '',
+				'filtered'    => '',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'content'     => '',
+				'filtered'    => '',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_default_block_if_name_is_defined_and_content_is_not_empty() {
+		$block = $this->freeform->export_block(
+			[
+				'name'        => 'core/paragraph',
+				'content'     => '<p>Block with no name</p>',
+				'filtered'    => 'Block with no name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'        => 'core/paragraph',
+				'content'     => '<p>Block with no name</p>',
+				'filtered'    => 'Block with no name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_modified_block_if_name_is_undefined_and_content_is_not_empty() {
+		$block = $this->freeform->export_block(
+			[
+				'content'     => '<p>Block with no name</p>',
+				'filtered'    => 'Block with no name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'content'     => '<p>Block with no name</p>',
+				'filtered'    => 'Block with no name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+				'name'        => 'core/freeform',
+			]
+		);
+	}
+}


### PR DESCRIPTION
This PR resolves [WP-127](https://appworld.atlassian.net/browse/WP-127).

## Description / Background Context

Now that we have implementation for the Freeform block, we need to add unit tests to provide test coverage for the same block. This PR introduces basic unit tests for same.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn install && yarn build`.
- Run `composer run test`.
- Observe that all test cases pass correctly.

---

<img width="600" alt="Screenshot 2026-02-23 at 00 52 40" src="https://github.com/user-attachments/assets/ea42a7fd-df9f-4986-a027-878eb9f1b7d7" />
