### PR TITLE
Test: Table block

### DIFF
--- a/inc/Abstracts/Block.php
+++ b/inc/Abstracts/Block.php
@@ -85,15 +85,23 @@ abstract class Block {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @param string $markup Block markup.
-	 * @param string $tag    Specific tag.
+	 * @param string  $markup Block markup.
+	 * @param string  $tag    Specific tag.
+	 * @param boolean $single True to match only a single element.
+	 *                        False to match all elements.
 	 *
-	 * @return string
+	 * @return string|array
 	 */
-	public function get_tag_content( $markup, $tag ): string {
-		preg_match( sprintf( '/<%1$s>(.*?)<\/%1$s>/', $tag ), $markup, $match );
+	public function get_tag_content( $markup, $tag, $single = true ) {
+		$reg_exp = sprintf( '/<%1$s>(.*?)<\/%1$s>/', $tag );
 
-		return $match[1] ?? '';
+		if ( $single ) {
+			preg_match( $reg_exp, $markup, $matches );
+			return $matches[1] ?? '';
+		}
+
+		preg_match_all( $reg_exp, $markup, $matches );
+		return $matches[1] ?? [];
 	}
 
 	/**

--- a/inc/Blocks/Table.php
+++ b/inc/Blocks/Table.php
@@ -69,8 +69,6 @@ class Table extends Block {
 
 		return array_map(
 			function ( $tr ) {
-				preg_match_all( '/<td>(.*?)<\/td>/', $tr, $matches );
-
 				$cells = array_map(
 					function ( $td ) {
 						return [
@@ -78,28 +76,14 @@ class Table extends Block {
 							'tag'     => 'td',
 						];
 					},
-					$matches[0] ?? []
+					$this->get_tag_content( $tr, 'td', false )
 				);
 
 				return [
 					'cells' => $cells,
 				];
 			},
-			$this->get_table_rows( $tbody )
+			$this->get_tag_content( $tbody, 'tr', false )
 		);
-	}
-
-	/**
-	 * Get Table Rows.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @param string $content Table markup nested in `tbody`.
-	 * @return mixed[]
-	 */
-	protected function get_table_rows( $content ): array {
-		preg_match_all( '/<tr>(.*?)<\/tr>/', $content, $matches );
-
-		return $matches[0] ?? [];
 	}
 }

--- a/tests/unit/php/Blocks/TableTest.php
+++ b/tests/unit/php/Blocks/TableTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace ConvertBlocksToJSON\Tests\Blocks;
+
+use WP_Mock;
+use Mockery;
+use ConvertBlocksToJSON\Blocks\Table;
+use Badasswp\WPMockTC\WPMockTestCase;
+
+/**
+ * @covers \ConvertBlocksToJSON\Blocks\Table::import_block
+ * @covers \ConvertBlocksToJSON\Blocks\Table::export_block
+ * @covers \ConvertBlocksToJSON\Blocks\Table::get_table_body
+ * @covers \ConvertBlocksToJSON\Abstracts\Block::get_tag_content
+ */
+class TableTest extends WPMockTestCase {
+	public Table $table;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->table = new Table();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+	}
+
+	public function test_import_block_returns_default_block_if_name_is_undefined() {
+		$block = $this->table->import_block(
+			[
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_import_block_returns_default_block_if_block_is_not_a_table() {
+		$block = $this->table->import_block(
+			[
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_import_block_returns_modified_block_with_added_body_attribute() {
+		$block = $this->table->import_block(
+			[
+				'name'        => 'core/table',
+				'attributes'  => '{"content":"<table><tbody><tr><td>Cell 1a<\/td><td>Cell 1b<\/td><\/tr><tr><td>Cell 2a<\/td><td>Cell 2b<\/td><\/tr><\/tbody><\/table>"}',
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'        => 'core/table',
+				'attributes'  => '{"content":"<table><tbody><tr><td>Cell 1a<\/td><td>Cell 1b<\/td><\/tr><tr><td>Cell 2a<\/td><td>Cell 2b<\/td><\/tr><\/tbody><\/table>","body":[{"cells":[{"content":"Cell 1a","tag":"td"},{"content":"Cell 1b","tag":"td"}]},{"cells":[{"content":"Cell 2a","tag":"td"},{"content":"Cell 2b","tag":"td"}]}]}',
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_default_block_if_name_is_undefined() {
+		$block = $this->table->export_block(
+			[
+				'content'     => '<p>Block with no name</p>',
+				'filtered'    => 'Block with no name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'content'     => '<p>Block with no name</p>',
+				'filtered'    => 'Block with no name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_default_block_if_it_is_not_a_table_block() {
+		$block = $this->table->export_block(
+			[
+				'name'        => 'core/paragraph',
+				'content'     => '<p>Block with name</p>',
+				'filtered'    => 'Block with no name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'        => 'core/paragraph',
+				'content'     => '<p>Block with name</p>',
+				'filtered'    => 'Block with no name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_same_block_if_it_is_a_table() {
+		$block = $this->table->export_block(
+			[
+				'name'        => 'core/table',
+				'content'     => '<table><tbody><tr><td>Cell 1a</td><td>Cell 1b</td></tr><tr><td>Cell 2a</td><td>Cell 2b</td></tr></tbody></table>',
+				'filtered'    => 'Cell1aCell1bCell2aCell2b',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'        => 'core/table',
+				'content'     => '<table><tbody><tr><td>Cell 1a</td><td>Cell 1b</td></tr><tr><td>Cell 2a</td><td>Cell 2b</td></tr></tbody></table>',
+				'filtered'    => 'Cell1aCell1bCell2aCell2b',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+	}
+}


### PR DESCRIPTION
This PR resolves [WP-135](https://appworld.atlassian.net/browse/WP-135).

## Description / Background Context

Now that we have implementation for the Table block, we need to add unit tests to provide test coverage for the same block. This PR introduces basic unit tests for same.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn install && yarn build`.
- Run `composer run test`.
- Observe that all test cases pass correctly.

---

<img width="600" alt="Screenshot 2026-02-23 at 00 52 40" src="https://github.com/user-attachments/assets/ea42a7fd-df9f-4986-a027-878eb9f1b7d7" />
