### PR TITLE
Test: Add unit tests for Lists block

### DIFF
--- a/tests/unit/php/Blocks/ListItemTest.php
+++ b/tests/unit/php/Blocks/ListItemTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace ConvertBlocksToJSON\Tests\Blocks;
+
+use WP_Mock;
+use Mockery;
+use ConvertBlocksToJSON\Blocks\ListItem;
+use Badasswp\WPMockTC\WPMockTestCase;
+
+/**
+ * @covers \ConvertBlocksToJSON\Blocks\ListItem::import_block
+ * @covers \ConvertBlocksToJSON\Blocks\ListItem::export_block
+ * @covers \ConvertBlocksToJSON\Abstracts\Block::get_clean_markup
+ */
+class ListItemTest extends WPMockTestCase {
+	public ListItem $list_item;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->list_item = new ListItem();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+	}
+
+	public function test_import_block_returns_original_block_if_name_is_undefined() {
+		$nameless_block = [
+			'attributes'  => '{}',
+			'innerBlocks' => [],
+		];
+
+		$response = $this->list_item->import_block( $nameless_block );
+
+		$this->assertSame( $response, $nameless_block );
+	}
+
+	public function test_import_block_returns_original_block_if_name_is_not_a_list_item() {
+		$non_list_item_block = [
+			'name'        => 'core/paragraph',
+			'attributes'  => '{}',
+			'innerBlocks' => [],
+		];
+
+		$response = $this->list_item->import_block( $non_list_item_block );
+
+		$this->assertSame( $response, $non_list_item_block );
+	}
+
+	public function test_import_block_returns_modified_block_with_cleaned_content_attribute() {
+		$list_block = [
+			'name'        => 'core/list-item',
+			'attributes'  => '{"content":"<li><li>Item 1<\/li><\/li>"}',
+			'innerBlocks' => [],
+		];
+
+		$response = $this->list_item->import_block( $list_block );
+
+		$this->assertSame(
+			$response,
+			[
+				'name'        => 'core/list-item',
+				'attributes'  => '{"content":"Item 1"}',
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_default_block_if_name_is_undefined() {
+		$block = $this->list_item->export_block(
+			[
+				'content'     => '<p>Block with no name</p>',
+				'filtered'    => 'Block with no name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'content'     => '<p>Block with no name</p>',
+				'filtered'    => 'Block with no name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_default_block_if_it_is_not_a_list_item_block() {
+		$block = $this->list_item->export_block(
+			[
+				'name'        => 'core/paragraph',
+				'content'     => '<p>Block with name</p>',
+				'filtered'    => 'Block with name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'        => 'core/paragraph',
+				'content'     => '<p>Block with name</p>',
+				'filtered'    => 'Block with name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_same_block_if_it_is_a_list_item() {
+		$block = $this->list_item->export_block(
+			[
+				'name'        => 'core/list-item',
+				'content'     => '<li>Block with name</li>',
+				'filtered'    => 'Block with name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'        => 'core/list-item',
+				'content'     => '<li>Block with name</li>',
+				'filtered'    => 'Block with name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+	}
+}

--- a/tests/unit/php/Blocks/ListsTest.php
+++ b/tests/unit/php/Blocks/ListsTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace ConvertBlocksToJSON\Tests\Blocks;
+
+use WP_Mock;
+use Mockery;
+use ConvertBlocksToJSON\Blocks\Lists;
+use Badasswp\WPMockTC\WPMockTestCase;
+
+/**
+ * @covers \ConvertBlocksToJSON\Blocks\Lists::import_block
+ * @covers \ConvertBlocksToJSON\Blocks\Lists::export_block
+ */
+class ListsTest extends WPMockTestCase {
+	public Lists $lists;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->lists = new Lists();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+	}
+
+	public function test_import_block_returns_original_block_if_name_is_undefined() {
+		$nameless_block = [
+			'attributes'  => '{}',
+			'innerBlocks' => [],
+		];
+
+		$response = $this->lists->import_block( $nameless_block );
+
+		$this->assertSame( $response, $nameless_block );
+	}
+
+	public function test_import_block_returns_original_block_if_name_is_not_a_list() {
+		$non_list_block = [
+			'name'        => 'core/paragraph',
+			'attributes'  => '{}',
+			'innerBlocks' => [],
+		];
+
+		$response = $this->lists->import_block( $non_list_block );
+
+		$this->assertSame( $response, $non_list_block );
+	}
+
+	public function test_import_block_removes_content_property_from_attribute() {
+		$list_block = [
+			'name'        => 'core/list',
+			'attributes'  => '{"content":"The list content"}',
+			'innerBlocks' => [],
+		];
+
+		$response = $this->lists->import_block( $list_block );
+
+		$this->assertSame(
+			$response,
+			[
+				'name'        => 'core/list',
+				'attributes'  => '[]',
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_default_block_if_name_is_undefined() {
+		$block = $this->lists->export_block(
+			[
+				'content'     => '<p>Block with no name</p>',
+				'filtered'    => 'Block with no name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'content'     => '<p>Block with no name</p>',
+				'filtered'    => 'Block with no name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_default_block_if_it_is_not_a_list_block() {
+		$block = $this->lists->export_block(
+			[
+				'name'        => 'core/paragraph',
+				'content'     => '<p>Block with name</p>',
+				'filtered'    => 'Block with name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'        => 'core/paragraph',
+				'content'     => '<p>Block with name</p>',
+				'filtered'    => 'Block with name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_same_block_if_it_is_a_list() {
+		$block = $this->lists->export_block(
+			[
+				'name'        => 'core/list',
+				'content'     => '<ul><li>Block with name</li></ul>',
+				'filtered'    => 'Block with name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'        => 'core/list',
+				'content'     => '<ul><li>Block with name</li></ul>',
+				'filtered'    => 'Block with name',
+				'attributes'  => [],
+				'innerBlocks' => [],
+			]
+		);
+	}
+}


### PR DESCRIPTION
This PR resolves [WP-130](https://appworld.atlassian.net/browse/WP-130).

## Description / Background Context

Now that we have implementation for the Lists block, we need to add unit tests to provide test coverage for the same block. This PR introduces basic unit tests for same.

## Testing Instructions

- Pull PR to local.
- Run `composer run test`.
- Observe that all test cases pass correctly.

---

<img width="600" alt="Screenshot 2026-02-23 at 00 52 40" src="https://github.com/user-attachments/assets/ea42a7fd-df9f-4986-a027-878eb9f1b7d7" />