### PR TITLE
Fix: Video issues under media block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix: Import issues with `core/media-text` block.
 * Fix: Import issues with `core/gallery` block.
 * Fix: Import issues with `core/audio` block.
+* Fix: Import issues with `core/video` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/inc/Blocks/Video.php
+++ b/inc/Blocks/Video.php
@@ -52,7 +52,7 @@ class Video extends Block {
 	/**
 	 * Export Block.
 	 *
-	 * @since 1.2.0
+	 * @since 1.3.0
 	 *
 	 * @param mixed[] $block Export Block.
 	 * @return mixed[]

--- a/inc/Blocks/Video.php
+++ b/inc/Blocks/Video.php
@@ -28,7 +28,7 @@ class Video extends Block {
 		}
 
 		// Decode attributes correctly.
-		$block['attributes'] = json_decode( $block['attributes'] ?? '', true );
+		$block['attributes'] = json_decode( $block['attributes'] ?? '{}', true );
 
 		// Ensure missing SRC attribute is captured for video blocks.
 		preg_match( '/src="([^"]+)"/', $block['attributes']['content'] ?? '', $matches );

--- a/inc/Blocks/Video.php
+++ b/inc/Blocks/Video.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Video Block.
+ *
+ * This class is responsible for customizing
+ * the Video block output.
+ *
+ * @package ConvertBlocksToJSON
+ */
+
+namespace ConvertBlocksToJSON\Blocks;
+
+use ConvertBlocksToJSON\Abstracts\Block;
+
+class Video extends Block {
+	/**
+	 * Import Block.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed[] $block Import Block.
+	 * @return mixed[]
+	 */
+	public function import_block( $block ): array {
+		// Bail out, if undefined OR not Video block.
+		if ( empty( $block['name'] ) || 'core/video' !== $block['name'] ) {
+			return $block;
+		}
+
+		// Decode attributes correctly.
+		$block['attributes'] = json_decode( $block['attributes'] ?? '', true );
+
+		// Ensure missing SRC attribute is captured for video blocks.
+		preg_match( '/src="([^"]+)"/', $block['attributes']['content'] ?? '', $matches );
+		$block['attributes']['src'] = esc_url( $matches[1] ?? '' );
+
+		// If it's not same site, get remote file.
+		if ( false === strpos( $block['attributes']['src'] ?? '', home_url() ) ) {
+			$remote_file = $this->get_remote_file( $block['attributes']['src'] ?? '' );
+
+			if ( ! is_wp_error( $remote_file ) ) {
+				$block['attributes']['src'] = $remote_file;
+			}
+		}
+
+		// Re-encode attributes correctly.
+		$block['attributes'] = wp_json_encode( $block['attributes'] ?? [] );
+
+		return $block;
+	}
+
+	/**
+	 * Export Block.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param mixed[] $block Export Block.
+	 * @return mixed[]
+	 */
+	public function export_block( $block ): array {
+		// Bail out, if undefined OR not Video block.
+		if ( empty( $block['name'] ) || 'core/video' !== $block['name'] ) {
+			return $block;
+		}
+
+		return $block;
+	}
+}

--- a/inc/Services/Blocks.php
+++ b/inc/Services/Blocks.php
@@ -22,6 +22,7 @@ use ConvertBlocksToJSON\Blocks\Paragraph;
 use ConvertBlocksToJSON\Blocks\Pullquote;
 use ConvertBlocksToJSON\Blocks\Table;
 use ConvertBlocksToJSON\Blocks\Video;
+
 use ConvertBlocksToJSON\Abstracts\Block;
 use ConvertBlocksToJSON\Abstracts\Service;
 use ConvertBlocksToJSON\Interfaces\Kernel;

--- a/inc/Services/Blocks.php
+++ b/inc/Services/Blocks.php
@@ -21,6 +21,7 @@ use ConvertBlocksToJSON\Blocks\MediaText;
 use ConvertBlocksToJSON\Blocks\Paragraph;
 use ConvertBlocksToJSON\Blocks\Pullquote;
 use ConvertBlocksToJSON\Blocks\Table;
+use ConvertBlocksToJSON\Blocks\Video;
 use ConvertBlocksToJSON\Abstracts\Block;
 use ConvertBlocksToJSON\Abstracts\Service;
 use ConvertBlocksToJSON\Interfaces\Kernel;
@@ -55,6 +56,7 @@ class Blocks extends Service implements Kernel {
 			Paragraph::class,
 			Pullquote::class,
 			Table::class,
+			Video::class,
 		];
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 * Fix: Import issues with `core/media-text` block.
 * Fix: Import issues with `core/gallery` block.
 * Fix: Import issues with `core/audio` block.
+* Fix: Import issues with `core/video` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/tests/unit/php/Services/BlocksTest.php
+++ b/tests/unit/php/Services/BlocksTest.php
@@ -19,6 +19,7 @@ use ConvertBlocksToJSON\Blocks\MediaText;
 use ConvertBlocksToJSON\Blocks\Paragraph;
 use ConvertBlocksToJSON\Blocks\Pullquote;
 use ConvertBlocksToJSON\Blocks\Table;
+use ConvertBlocksToJSON\Blocks\Video;
 
 /**
  * @covers \ConvertBlocksToJSON\Services\Blocks::__construct
@@ -53,6 +54,7 @@ class BlocksTest extends WPMockTestCase {
 				Paragraph::class,
 				Pullquote::class,
 				Table::class,
+				Video::class,
 			],
 			$this->blocks->blocks
 		);
@@ -101,6 +103,7 @@ class BlocksTest extends WPMockTestCase {
 				Paragraph::class,
 				Pullquote::class,
 				Table::class,
+				Video::class,
 			]
 		);
 


### PR DESCRIPTION
This PR resolves [WP-108](https://appworld.atlassian.net/browse/WP-108).

## Description / Background Context

At the moment, when we import a Video block, we see that the block does not import correctly as expected. The video does NOT appear after import. The expected behaviour should be that after import, video should display.

This PR implements a fix for this issue.

## Testing Instructions

- Pull PR to local.
- Head over to `tastewp.com` [here](https://tastewp.com/create/NMS/8.0/6.7.0/convert-blocks-to-json/twentytwentythree?ni=true&origin=wp) and spin up a new WP instance.
- Now create a video block by typing `/video` into the block editor (**make sure to insert a video**) and publish the post.
- Locate the `Convert Blocks to JSON` icon and export the blocks into a JSON file.
- (**For Engineers**) - Go back to your local environment and import the JSON file. (**For QA**) please use the [test](https://aw-wp-env.com/wp-admin/) server and import the JSON file.
- Observe that the Video block is now working correctly and the video is displaying.

---
<img width="1919" height="763" alt="Screenshot 2026-02-24 122548" src="https://github.com/user-attachments/assets/9ce1c311-14cb-41a8-a467-e3ca0a018e75" />
