### PR TITLE
Fix: Freeform issues bleeding over into JSON

### DIFF
--- a/inc/Blocks/Freeform.php
+++ b/inc/Blocks/Freeform.php
@@ -40,7 +40,7 @@ class Freeform extends Block {
 	 */
 	public function export_block( $block ): array {
 		// Treat as Freeform block.
-		if ( empty( $block['name'] ) && ! empty( $block['content'] ) ) {
+		if ( empty( $block['name'] ) && ! empty( trim( $block['content'] ) ) ) {
 			$block['name'] = 'core/freeform';
 		}
 


### PR DESCRIPTION
This PR resolves [WP-136](https://appworld.atlassian.net/browse/WP-136).

## Description / Background Context

At the moment, when we view the JSON CAPI (Content API) we see that it contains empty Freeform blocks. This should not be the case. The expected behaviour should be that when we view the JSON CAPI we only see Freeform blocks that have content alongside other blocks.

This PR implements a fix for this issue.

## Testing Instructions

- Pull PR to local.
- (**For Engineers**), please use your local environment, (**For QA**) use the [test](https://aw-wp-env.com/wp-admin/) server.
- Create a Classic block by typing `/classic` into the block editor (**make sure to put a text in it**) and publish the post.
- Locate the `Convert Blocks to JSON` icon, click the `VIEW JSON` button.
- Observe that the JSON doesn't contain any empty `core/freeform` content.

---


<img width="1919" height="483" alt="Screenshot 2026-02-24 141857" src="https://github.com/user-attachments/assets/abdfe084-a95c-4cde-9342-adbdffebfb18" />
