### PR TITLE
Test: Add unit tests for paragraph block

### DIFF
--- a/tests/unit/php/Blocks/ParagraphTest.php
+++ b/tests/unit/php/Blocks/ParagraphTest.php
@@ -69,7 +69,9 @@ class ParagraphTest extends WPMockTestCase {
 
 	public function test_export_block_returns_original_block_if_name_is_undefined() {
 		$nameless_block = [
-			'attributes'  => '{}',
+			'content'     => '<h1>Block with name</h1>',
+			'filtered'    => 'Block with name',
+			'attributes'  => [],
 			'innerBlocks' => [],
 		];
 
@@ -80,8 +82,10 @@ class ParagraphTest extends WPMockTestCase {
 
 	public function test_export_block_returns_original_block_if_name_is_not_paragraph() {
 		$non_paragraph_block = [
-			'name'        => 'core/list',
-			'attributes'  => '{}',
+			'name'        => 'core/heading',
+			'content'     => '<h1>Block with name</h1>',
+			'filtered'    => 'Block with name',
+			'attributes'  => [],
 			'innerBlocks' => [],
 		];
 
@@ -93,7 +97,9 @@ class ParagraphTest extends WPMockTestCase {
 	public function test_export_block_returns_same_block_if_it_is_a_paragraph() {
 		$paragraph_block = [
 			'name'        => 'core/paragraph',
-			'attributes'  => '{"content":"<p>This content should be returned without the tags.</p>"}',
+			'content'     => '<p><p>This content should be returned without the tags.</p></p>',
+			'filtered'    => 'This content should be returned without the tags.',
+			'attributes'  => [],
 			'innerBlocks' => [],
 		];
 
@@ -103,7 +109,9 @@ class ParagraphTest extends WPMockTestCase {
 			$response,
 			[
 				'name'        => 'core/paragraph',
-				'attributes'  => '{"content":"<p>This content should be returned without the tags.</p>"}',
+				'content'     => '<p><p>This content should be returned without the tags.</p></p>',
+				'filtered'    => 'This content should be returned without the tags.',
+				'attributes'  => [],
 				'innerBlocks' => [],
 			]
 		);

--- a/tests/unit/php/Blocks/ParagraphTest.php
+++ b/tests/unit/php/Blocks/ParagraphTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace ConvertBlocksToJSON\Tests\Blocks;
+
+use WP_Mock;
+use Mockery;
+use ConvertBlocksToJSON\Blocks\Paragraph;
+use Badasswp\WPMockTC\WPMockTestCase;
+
+/**
+ * @covers \ConvertBlocksToJSON\Blocks\Paragraph::import_block
+ * @covers \ConvertBlocksToJSON\Blocks\Paragraph::export_block
+ */
+class ParagraphTest extends WPMockTestCase {
+	public Paragraph $paragraph;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->paragraph = new Paragraph();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+	}
+
+	public function test_import_block_returns_original_block_if_name_is_undefined(){
+		$nameless_block = [
+			'attributes'  =>'{}',
+			'innerBlocks' => [],
+		];
+
+		$response = $this->paragraph->import_block( $nameless_block );
+
+		$this->assertsame( $response, $nameless_block );
+	}
+
+	public function test_import_block_returns_original_block_if_name_is_not_paragraph(){
+		$non_paragraph_block = [
+			'name' 			=> 'core/list',
+			'attributes'	=> '{}',
+			'innerBlocks'	=> [],
+		];
+
+		$response = $this->paragraph->import_block( $non_paragraph_block );
+
+		$this->assertsame( $response, $non_paragraph_block );
+	}
+
+	public function test_import_block_returns_modified_block_with_cleaned_content_attribute(){
+		$paragraph_block = [
+			'name'			=> 'core/paragraph',
+			'attributes'	=> '{"content":"<p>This content should be returned without the tags.</p>"}',
+			'innerBlocks'	=> [],
+		];
+
+		$response = $this->paragraph->import_block( $paragraph_block );
+
+		$this->assertsame(
+			$response,
+			[
+				'name'			=> 'core/paragraph',
+				'attributes'	=> '{"content":"This content should be returned without the tags."}',
+				'innerBlocks'	=> [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_original_block_if_name_is_undefined(){
+		$nameless_block = [
+			'attributes'  =>'{}',
+			'innerBlocks' => [],
+		];
+
+		$response = $this->paragraph->export_block( $nameless_block );
+
+		$this->assertsame( $response, $nameless_block );
+	}
+
+	public function test_export_block_returns_original_block_if_name_is_not_paragraph(){
+		$non_paragraph_block = [
+			'name' 			=> 'core/list',
+			'attributes'	=> '{}',
+			'innerBlocks'	=> [],
+		];
+
+		$response = $this->paragraph->export_block( $non_paragraph_block );
+
+		$this->assertsame( $response, $non_paragraph_block );
+	}
+
+	public function test_export_block_returns_same_block_if_it_is_a_paragraph(){
+		$paragraph_block = [
+			'name'			=> 'core/paragraph',
+			'attributes'	=> '{"content":"<p>This content should be returned without the tags.</p>"}',
+			'innerBlocks'	=> [],
+		];
+
+		$response = $this->paragraph->export_block( $paragraph_block );
+
+		$this->assertsame(
+			$response,
+			[
+				'name'			=> 'core/paragraph',
+				'attributes'	=> '{"content":"<p>This content should be returned without the tags.</p>"}',
+				'innerBlocks'	=> [],
+			]
+		);
+	}
+}

--- a/tests/unit/php/Blocks/ParagraphTest.php
+++ b/tests/unit/php/Blocks/ParagraphTest.php
@@ -10,6 +10,7 @@ use Badasswp\WPMockTC\WPMockTestCase;
 /**
  * @covers \ConvertBlocksToJSON\Blocks\Paragraph::import_block
  * @covers \ConvertBlocksToJSON\Blocks\Paragraph::export_block
+ * @covers \ConvertBlocksToJSON\Abstracts\Block::get_clean_markup
  */
 class ParagraphTest extends WPMockTestCase {
 	public Paragraph $paragraph;

--- a/tests/unit/php/Blocks/ParagraphTest.php
+++ b/tests/unit/php/Blocks/ParagraphTest.php
@@ -51,7 +51,7 @@ class ParagraphTest extends WPMockTestCase {
 	public function test_import_block_returns_modified_block_with_cleaned_content_attribute() {
 		$paragraph_block = [
 			'name'        => 'core/paragraph',
-			'attributes'  => '{"content":"<p>This content should be returned without the tags.</p>"}',
+			'attributes'  => '{"content":"<p><p>This content should be returned without the tags.<\/p><\/p>"}',
 			'innerBlocks' => [],
 		];
 

--- a/tests/unit/php/Blocks/ParagraphTest.php
+++ b/tests/unit/php/Blocks/ParagraphTest.php
@@ -24,9 +24,9 @@ class ParagraphTest extends WPMockTestCase {
 		parent::tearDown();
 	}
 
-	public function test_import_block_returns_original_block_if_name_is_undefined(){
+	public function test_import_block_returns_original_block_if_name_is_undefined() {
 		$nameless_block = [
-			'attributes'  =>'{}',
+			'attributes'  => '{}',
 			'innerBlocks' => [],
 		];
 
@@ -35,11 +35,11 @@ class ParagraphTest extends WPMockTestCase {
 		$this->assertsame( $response, $nameless_block );
 	}
 
-	public function test_import_block_returns_original_block_if_name_is_not_paragraph(){
+	public function test_import_block_returns_original_block_if_name_is_not_paragraph() {
 		$non_paragraph_block = [
-			'name' 			=> 'core/list',
-			'attributes'	=> '{}',
-			'innerBlocks'	=> [],
+			'name'        => 'core/list',
+			'attributes'  => '{}',
+			'innerBlocks' => [],
 		];
 
 		$response = $this->paragraph->import_block( $non_paragraph_block );
@@ -47,11 +47,11 @@ class ParagraphTest extends WPMockTestCase {
 		$this->assertsame( $response, $non_paragraph_block );
 	}
 
-	public function test_import_block_returns_modified_block_with_cleaned_content_attribute(){
+	public function test_import_block_returns_modified_block_with_cleaned_content_attribute() {
 		$paragraph_block = [
-			'name'			=> 'core/paragraph',
-			'attributes'	=> '{"content":"<p>This content should be returned without the tags.</p>"}',
-			'innerBlocks'	=> [],
+			'name'        => 'core/paragraph',
+			'attributes'  => '{"content":"<p>This content should be returned without the tags.</p>"}',
+			'innerBlocks' => [],
 		];
 
 		$response = $this->paragraph->import_block( $paragraph_block );
@@ -59,16 +59,16 @@ class ParagraphTest extends WPMockTestCase {
 		$this->assertsame(
 			$response,
 			[
-				'name'			=> 'core/paragraph',
-				'attributes'	=> '{"content":"This content should be returned without the tags."}',
-				'innerBlocks'	=> [],
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":"This content should be returned without the tags."}',
+				'innerBlocks' => [],
 			]
 		);
 	}
 
-	public function test_export_block_returns_original_block_if_name_is_undefined(){
+	public function test_export_block_returns_original_block_if_name_is_undefined() {
 		$nameless_block = [
-			'attributes'  =>'{}',
+			'attributes'  => '{}',
 			'innerBlocks' => [],
 		];
 
@@ -77,11 +77,11 @@ class ParagraphTest extends WPMockTestCase {
 		$this->assertsame( $response, $nameless_block );
 	}
 
-	public function test_export_block_returns_original_block_if_name_is_not_paragraph(){
+	public function test_export_block_returns_original_block_if_name_is_not_paragraph() {
 		$non_paragraph_block = [
-			'name' 			=> 'core/list',
-			'attributes'	=> '{}',
-			'innerBlocks'	=> [],
+			'name'        => 'core/list',
+			'attributes'  => '{}',
+			'innerBlocks' => [],
 		];
 
 		$response = $this->paragraph->export_block( $non_paragraph_block );
@@ -89,11 +89,11 @@ class ParagraphTest extends WPMockTestCase {
 		$this->assertsame( $response, $non_paragraph_block );
 	}
 
-	public function test_export_block_returns_same_block_if_it_is_a_paragraph(){
+	public function test_export_block_returns_same_block_if_it_is_a_paragraph() {
 		$paragraph_block = [
-			'name'			=> 'core/paragraph',
-			'attributes'	=> '{"content":"<p>This content should be returned without the tags.</p>"}',
-			'innerBlocks'	=> [],
+			'name'        => 'core/paragraph',
+			'attributes'  => '{"content":"<p>This content should be returned without the tags.</p>"}',
+			'innerBlocks' => [],
 		];
 
 		$response = $this->paragraph->export_block( $paragraph_block );
@@ -101,9 +101,9 @@ class ParagraphTest extends WPMockTestCase {
 		$this->assertsame(
 			$response,
 			[
-				'name'			=> 'core/paragraph',
-				'attributes'	=> '{"content":"<p>This content should be returned without the tags.</p>"}',
-				'innerBlocks'	=> [],
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":"<p>This content should be returned without the tags.</p>"}',
+				'innerBlocks' => [],
 			]
 		);
 	}


### PR DESCRIPTION
This PR resolves [WP-133](https://appworld.atlassian.net/browse/WP-133).

## Description / Background Context

Now that we have implementation for the Paragraph block, we need to add unit tests to provide test coverage for the same block. This PR introduces basic unit tests for same.

## Testing Instructions

- Pull PR to local.
- Run `composer run test`.
- Observe that all test cases pass correctly.

---

<img width="1645" height="232" alt="Screenshot 2026-02-24 165002" src="https://github.com/user-attachments/assets/4a61d998-fe60-4c39-9ad1-d159962a5402" />
