### PR TITLE
Test: Add unit tests for pullquote block

### DIFF
--- a/tests/unit/php/Blocks/PullquoteTest.php
+++ b/tests/unit/php/Blocks/PullquoteTest.php
@@ -51,7 +51,7 @@ class PullquoteTest extends WPMockTestCase {
 	public function test_import_block_returns_modified_block_with_value_and_citation_attribute() {
 		$pullquote_block = [
 			'name'        => 'core/pullquote',
-			'attributes'  => '{"content":"<p>Don\'t be the Slave of Gold &amp; Silver<\/p><cite>Prophet Muhammad (s a w)<\/cite>"}',
+			'attributes'  => '{"content":"<p>This content should be returned<\/p><cite>John Doe<\/cite>"}',
 			'innerBlocks' => [],
 		];
 
@@ -61,7 +61,7 @@ class PullquoteTest extends WPMockTestCase {
 			$response,
 			[
 				'name'        => 'core/pullquote',
-				'attributes'  => '{"content":"<p>Don\'t be the Slave of Gold &amp; Silver<\/p><cite>Prophet Muhammad (s a w)<\/cite>","value":"Don\'t be the Slave of Gold &amp; Silver","citation":"Prophet Muhammad (s a w)"}',
+				'attributes'  => '{"content":"<p>This content should be returned<\/p><cite>John Doe<\/cite>","value":"This content should be returned","citation":"John Doe"}',
 				'innerBlocks' => [],
 			]
 		);
@@ -69,9 +69,9 @@ class PullquoteTest extends WPMockTestCase {
 
 	public function test_export_block_returns_original_block_if_name_is_undefined() {
 		$nameless_block = [
-			'content'	  => '',
+			'content'     => '',
 			'attributes'  => '{}',
-			'filtered'	  => '',
+			'filtered'    => '',
 			'innerBlocks' => [],
 		];
 
@@ -83,9 +83,9 @@ class PullquoteTest extends WPMockTestCase {
 	public function test_export_block_returns_original_block_if_name_is_not_pullquote() {
 		$non_pullquote_block = [
 			'name'        => 'core/paragraph',
-			'content'	  => '',
+			'content'     => '',
 			'attributes'  => '{}',
-			'filtered'	  => '',
+			'filtered'    => '',
 			'innerBlocks' => [],
 		];
 
@@ -97,8 +97,8 @@ class PullquoteTest extends WPMockTestCase {
 	public function test_export_block_returns_same_block_if_it_is_a_pullquote() {
 		$pullquote_block = [
 			'name'        => 'core/pullquote',
-			'content'	  => '<p>Don\'t be the Slave of Gold &amp; Silver<\/p><cite>Prophet Muhammad (s a w)<\/cite>',
-			'filtered'	  => 'Don\'t be the Slave of Gold &amp; SilverProphet Muhammad (s a w)',
+			'content'     => '<p>This content should be returned<\/p><cite>John Doe<\/cite>',
+			'filtered'    => 'This content should be returnedJohn Doe',
 			'attributes'  => [],
 			'innerBlocks' => [],
 		];

--- a/tests/unit/php/Blocks/PullquoteTest.php
+++ b/tests/unit/php/Blocks/PullquoteTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace ConvertBlocksToJSON\Tests\Blocks;
+
+use WP_Mock;
+use Mockery;
+use ConvertBlocksToJSON\Blocks\Pullquote;
+use Badasswp\WPMockTC\WPMockTestCase;
+
+/**
+ * @covers \ConvertBlocksToJSON\Blocks\Pullquote::import_block
+ * @covers \ConvertBlocksToJSON\Blocks\Pullquote::export_block
+ * @covers \ConvertBlocksToJSON\Abstracts\Block::get_tag_content
+ */
+class PullquoteTest extends WPMockTestCase {
+	public Pullquote $pullquote;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->pullquote = new Pullquote();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+	}
+
+	public function test_import_block_returns_original_block_if_name_is_undefined() {
+		$nameless_block = [
+			'attributes'  => '{}',
+			'innerBlocks' => [],
+		];
+
+		$response = $this->pullquote->import_block( $nameless_block );
+
+		$this->assertsame( $response, $nameless_block );
+	}
+
+	public function test_import_block_returns_original_block_if_name_is_not_pullquote() {
+		$non_pullquote_block = [
+			'name'        => 'core/paragraph',
+			'attributes'  => '{}',
+			'innerBlocks' => [],
+		];
+
+		$response = $this->pullquote->import_block( $non_pullquote_block );
+
+		$this->assertsame( $response, $non_pullquote_block );
+	}
+
+	public function test_import_block_returns_modified_block_with_value_and_citation_attribute() {
+		$pullquote_block = [
+			'name'        => 'core/pullquote',
+			'attributes'  => '{"content":"<p>Don\'t be the Slave of Gold &amp; Silver<\/p><cite>Prophet Muhammad (s a w)<\/cite>"}',
+			'innerBlocks' => [],
+		];
+
+		$response = $this->pullquote->import_block( $pullquote_block );
+
+		$this->assertsame(
+			$response,
+			[
+				'name'        => 'core/pullquote',
+				'attributes'  => '{"content":"<p>Don\'t be the Slave of Gold &amp; Silver<\/p><cite>Prophet Muhammad (s a w)<\/cite>","value":"Don\'t be the Slave of Gold &amp; Silver","citation":"Prophet Muhammad (s a w)"}',
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_original_block_if_name_is_undefined() {
+		$nameless_block = [
+			'content'	  => '',
+			'attributes'  => '{}',
+			'filtered'	  => '',
+			'innerBlocks' => [],
+		];
+
+		$response = $this->pullquote->export_block( $nameless_block );
+
+		$this->assertsame( $response, $nameless_block );
+	}
+
+	public function test_export_block_returns_original_block_if_name_is_not_pullquote() {
+		$non_pullquote_block = [
+			'name'        => 'core/paragraph',
+			'content'	  => '',
+			'attributes'  => '{}',
+			'filtered'	  => '',
+			'innerBlocks' => [],
+		];
+
+		$response = $this->pullquote->export_block( $non_pullquote_block );
+
+		$this->assertsame( $response, $non_pullquote_block );
+	}
+
+	public function test_export_block_returns_same_block_if_it_is_a_pullquote() {
+		$pullquote_block = [
+			'name'        => 'core/pullquote',
+			'content'	  => '<p>Don\'t be the Slave of Gold &amp; Silver<\/p><cite>Prophet Muhammad (s a w)<\/cite>',
+			'filtered'	  => 'Don\'t be the Slave of Gold &amp; SilverProphet Muhammad (s a w)',
+			'attributes'  => [],
+			'innerBlocks' => [],
+		];
+
+		$response = $this->pullquote->export_block( $pullquote_block );
+
+		$this->assertsame( $response, $pullquote_block );
+	}
+}

--- a/tests/unit/php/Blocks/PullquoteTest.php
+++ b/tests/unit/php/Blocks/PullquoteTest.php
@@ -97,7 +97,7 @@ class PullquoteTest extends WPMockTestCase {
 	public function test_export_block_returns_same_block_if_it_is_a_pullquote() {
 		$pullquote_block = [
 			'name'        => 'core/pullquote',
-			'content'     => '<p>This content should be returned<\/p><cite>John Doe<\/cite>',
+			'content'     => '<p>This content should be returned</p><cite>John Doe</cite>',
 			'filtered'    => 'This content should be returnedJohn Doe',
 			'attributes'  => [],
 			'innerBlocks' => [],


### PR DESCRIPTION
This PR resolves [WP-134](https://appworld.atlassian.net/browse/WP-134).

## Description / Background Context

Now that we have implementation for the Pullquote block, we need to add unit tests to provide test coverage for the same block. This PR introduces basic unit tests for same.

## Testing Instructions

- Pull PR to local.
- Run `composer run test`.
- Observe that all test cases pass correctly.

---

<img width="1023" height="211" alt="image" src="https://github.com/user-attachments/assets/f6237c0e-4a99-496f-92ce-d99c75b08322" />

