### PR TITLE
Feat: Add Footnotes block class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.3.0
 * Feat: Add language translations for Japanese, Indonesia, Turkish, Polish, Dutch, Danish, Brazil, Portuguese.
 * Feat: Add Image import functionality across websites.
-* Feat: Add custom hook - `cbtj.innerBlocks`.
+* Feat: Add custom hooks - `cbtj.afterImport`, `cbtj.innerBlocks`.
 * Feat: Add Notification modal during import.
 * Feat: Clear previous notifications before starting import.
 * Fix: Import issues with `core/list` and `core/list-item` blocks.
@@ -18,6 +18,7 @@
 * Fix: Import issues with `core/gallery` block.
 * Fix: Import issues with `core/audio` block.
 * Fix: Import issues with `core/video` block.
+* Fix: Import issues with `core/footnotes` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,30 @@ public function custom_namespace( $namespace ): array {
 - namespace _`{string}`_ REST Namespace. By default, this is a string which contains the Route namespace.
 <br/>
 
+#### `cbtj.afterImport`
+
+This custom hook (action) provides the ability to fire some logic after the import is completed like so:
+
+```js
+import { addAction } from '@wordpress/hooks';
+
+addFilter(
+    'cbtj.afterImport',
+    'yourNamespace',
+    ( { blocks } ) => {
+        if ( blocks.some( ( { name } === 'core/footnotes' ) ) ) {
+            editPost( { title: 'A footnote was imported' } );
+        }
+    }
+);
+```
+
+**Parameters**
+
+- title _`{string}`_ Post title.
+- blocks _`{any[]}`_ Array of imported blocks.
+<br/>
+
 #### `cbtj.innerBlocks`
 
 This custom hook (filter) provides the ability to filter the way we create the inner blocks like so:

--- a/inc/Blocks/Footnotes.php
+++ b/inc/Blocks/Footnotes.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Footnotes Block.
+ *
+ * This class is responsible for customizing
+ * the Footnotes block output.
+ *
+ * @package ConvertBlocksToJSON
+ */
+
+namespace ConvertBlocksToJSON\Blocks;
+
+use ConvertBlocksToJSON\Abstracts\Block;
+
+class Footnotes extends Block {
+	/**
+	 * Import Block.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed[] $block Import Block.
+	 * @return mixed[]
+	 */
+	public function import_block( $block ): array {
+		// Bail out, if undefined OR not Footnotes block.
+		if ( empty( $block['name'] ) || 'core/footnotes' !== $block['name'] ) {
+			return $block;
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Export Block.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param mixed $block Export Block.
+	 * @return mixed[]
+	 */
+	public function export_block( $block ): array {
+		// Bail out, if undefined OR not Footnotes block.
+		if ( empty( $block['name'] ) || 'core/footnotes' !== $block['name'] ) {
+			return $block;
+		}
+
+		// Get Post ID.
+		$post_id = absint( basename( wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ) ) );
+
+		// Set the content.
+		$block['attributes']['footnotes'] = get_post_meta( $post_id, 'footnotes', true );
+
+		return $block;
+	}
+}

--- a/inc/Services/Blocks.php
+++ b/inc/Services/Blocks.php
@@ -12,6 +12,7 @@ namespace ConvertBlocksToJSON\Services;
 
 use ConvertBlocksToJSON\Blocks\Audio;
 use ConvertBlocksToJSON\Blocks\Details;
+use ConvertBlocksToJSON\Blocks\Footnotes;
 use ConvertBlocksToJSON\Blocks\Freeform;
 use ConvertBlocksToJSON\Blocks\Heading;
 use ConvertBlocksToJSON\Blocks\Image;
@@ -48,6 +49,7 @@ class Blocks extends Service implements Kernel {
 		$this->blocks = [
 			Audio::class,
 			Details::class,
+			Footnotes::class,
 			Freeform::class,
 			Heading::class,
 			Image::class,

--- a/readme.txt
+++ b/readme.txt
@@ -73,7 +73,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 = 1.3.0 =
 * Feat: Add language translations for Japanese, Indonesia, Turkish, Polish, Dutch, Danish, Brazil, Portuguese.
 * Feat: Add Image import functionality across websites.
-* Feat: Add custom hook - `cbtj.innerBlocks`.
+* Feat: Add custom hooks - `cbtj.afterImport`, `cbtj.innerBlocks`.
 * Feat: Add Notification modal during import.
 * Feat: Clear previous notifications before starting import.
 * Fix: Import issues with `core/list` and `core/list-item` blocks.
@@ -88,6 +88,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 * Fix: Import issues with `core/gallery` block.
 * Fix: Import issues with `core/audio` block.
 * Fix: Import issues with `core/video` block.
+* Fix: Import issues with `core/footnotes` block.
 * Fix: Incorrectly quoted translation bits.
 * Refactor: Replace `get_400_response` with `get_error_response`.
 * Test: Add e2e tests for plugin codebase.

--- a/src/components/ImportJSON.tsx
+++ b/src/components/ImportJSON.tsx
@@ -83,13 +83,13 @@ const ImportJSON = (): JSX.Element => {
 
 		try {
 			// Get data.
-			const { title, content } = await getImport( attachment );
+			const { title, content: blocks } = await getImport( attachment );
 
 			// Add title.
 			editPost( { title, status: 'publish' } );
 
-			// Add content.
-			content.forEach( ( { name, attributes, innerBlocks } ) => {
+			// Add blocks.
+			blocks.forEach( ( { name, attributes, innerBlocks } ) => {
 				attributes = JSON.parse( attributes );
 				(
 					dispatch( blockEditorStore ) as { insertBlocks: any }

--- a/src/components/ImportJSON.tsx
+++ b/src/components/ImportJSON.tsx
@@ -5,6 +5,7 @@ import { createBlock } from '@wordpress/blocks';
 import { store as editorStore } from '@wordpress/editor';
 import { store as noticeStore } from '@wordpress/notices';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { doAction } from '@wordpress/hooks';
 
 import { getModalParams, getImport, getInnerBlocks } from '../utils';
 
@@ -105,6 +106,19 @@ const ImportJSON = (): JSX.Element => {
 			// Save Post.
 			await savePost();
 			dispatch( noticeStore ).removeNotice( 'cbtj-info' );
+
+			/**
+			 * Fires the action after the import
+			 * of the blocks is complete.
+			 *
+			 * @since 1.3.0
+			 *
+			 * @param {string} title  Post title.
+			 * @param {any[]}  blocks Imported blocks.
+			 *
+			 * @return {void}
+			 */
+			doAction( 'cbtj.afterImport', { title, blocks } );
 		} catch ( e ) {
 			dispatch( noticeStore ).createWarningNotice( e.message );
 		}

--- a/src/filters.tsx
+++ b/src/filters.tsx
@@ -1,5 +1,38 @@
-import { addFilter } from '@wordpress/hooks';
+import { dispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
+import { addAction, addFilter } from '@wordpress/hooks';
+import { store as editorStore } from '@wordpress/editor';
+
+/**
+ * Fires the action after the import
+ * of the blocks is complete.
+ *
+ * @since 1.3.0
+ *
+ * @param {string} title   Post title.
+ * @param {any[]}  content Imported blocks.
+ *
+ * @return {void}
+ */
+addAction( 'cbtj.afterImport', 'cbtj', async ( { blocks } ) => {
+	const { editPost, savePost } = dispatch( editorStore ) as {
+		editPost: any;
+		savePost: any;
+	};
+
+	const footnote = blocks.filter( ( { name } ) => name === 'core/footnotes' );
+
+	// Update post meta for core/footnotes after import.
+	if ( footnote.length === 1 ) {
+		const { footnotes } = JSON.parse( footnote[ 0 ].attributes );
+		editPost( {
+			meta: {
+				footnotes,
+			},
+		} );
+		await savePost();
+	}
+} );
 
 /**
  * Filter the way we handle the innerBlocks

--- a/tests/unit/php/Services/BlocksTest.php
+++ b/tests/unit/php/Services/BlocksTest.php
@@ -10,6 +10,7 @@ use ConvertBlocksToJSON\Services\Blocks;
 
 use ConvertBlocksToJSON\Blocks\Audio;
 use ConvertBlocksToJSON\Blocks\Details;
+use ConvertBlocksToJSON\Blocks\Footnotes;
 use ConvertBlocksToJSON\Blocks\Freeform;
 use ConvertBlocksToJSON\Blocks\Heading;
 use ConvertBlocksToJSON\Blocks\Image;
@@ -45,6 +46,7 @@ class BlocksTest extends WPMockTestCase {
 			[
 				Audio::class,
 				Details::class,
+				Footnotes::class,
 				Freeform::class,
 				Heading::class,
 				Image::class,
@@ -94,6 +96,7 @@ class BlocksTest extends WPMockTestCase {
 			[
 				Audio::class,
 				Details::class,
+				Footnotes::class,
 				Freeform::class,
 				Heading::class,
 				Image::class,


### PR DESCRIPTION
This PR resolves [WP-139](https://appworld.atlassian.net/browse/WP-139).

## Description / Background Context

At the moment, when we import any block that has a footnote reference, we see that the `Footnote` block does not import correctly as expected. The expected behaviour should be that when the block is imported the `Footnote` reference should also be imported correctly.

This PR implements a fix for this issue.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn install && yarn build`.
- (**For Engineers**), please use your local environment, (**For QA**) use the [test](https://aw-wp-env.com/wp-admin/) server.
- Now create a paragraph block and add a footnote reference to it (**this will automatically add a footnotes block**).
- Publish the Post.
- Locate the `Convert Blocks to JSON` icon and export the blocks into a JSON file.
- **Using the same environment**, please import the JSON file.
- Observe that the Footnotes block is now imported and working correctly.