### PR TITLE
Fix: Table Import issues & Missing table parts

### DIFF
--- a/inc/Abstracts/Block.php
+++ b/inc/Abstracts/Block.php
@@ -93,7 +93,7 @@ abstract class Block {
 	 * @return string|array
 	 */
 	public function get_tag_content( $markup, $tag, $single = true ) {
-		$reg_exp = sprintf( '/<%1$s>(.*?)<\/%1$s>/', $tag );
+		$reg_exp = sprintf( '/<%1$s\b[^>]*>(.*?)<\/%1$s>/', $tag );
 
 		if ( $single ) {
 			preg_match( $reg_exp, $markup, $matches );

--- a/inc/Blocks/Table.php
+++ b/inc/Blocks/Table.php
@@ -30,8 +30,16 @@ class Table extends Block {
 		// Decode attributes correctly.
 		$block['attributes'] = json_decode( $block['attributes'] ?? '{}', true );
 
-		// Set the body.
-		$block['attributes']['body'] = $this->get_table_body( $block['attributes']['content'] ?? '' );
+		// Get table content.
+		$table_content = $block['attributes']['content'] ?? '';
+
+		// Set the table parts.
+		$block['attributes']['head'] = $this->get_table_part( $table_content, 'thead', 'th' );
+		$block['attributes']['body'] = $this->get_table_part( $table_content, 'tbody', 'td' );
+		$block['attributes']['foot'] = $this->get_table_part( $table_content, 'tfoot', 'td' );
+
+		// Set the table caption.
+		$block['attributes']['caption'] = $this->get_tag_content( $table_content, 'figcaption' );
 
 		// Re-encode attributes correctly.
 		$block['attributes'] = wp_json_encode( $block['attributes'] ?? [] );

--- a/inc/Blocks/Table.php
+++ b/inc/Blocks/Table.php
@@ -57,33 +57,36 @@ class Table extends Block {
 	}
 
 	/**
-	 * Get Table body.
+	 * Get Table part.
 	 *
 	 * @since 1.3.0
 	 *
 	 * @param string $content Table markup or innerHTML.
+	 * @param string $part    Table part for e.g. 'tbody'.
+	 * @param string $cell    Table cell name for e.g. 'td'.
+	 *
 	 * @return mixed[]
 	 */
-	protected function get_table_body( $content ): array {
-		$tbody = $this->get_tag_content( $content, 'tbody' );
+	protected function get_table_part( $content, $part, $cell ): array {
+		$section = $this->get_tag_content( $content, $part );
 
 		return array_map(
-			function ( $tr ) {
+			function ( $tr ) use ( $cell ) {
 				$cells = array_map(
-					function ( $td ) {
+					function ( $td ) use ( $cell ) {
 						return [
 							'content' => $td,
-							'tag'     => 'td',
+							'tag'     => $cell,
 						];
 					},
-					$this->get_tag_content( $tr, 'td', false )
+					$this->get_tag_content( $tr, $cell, false )
 				);
 
 				return [
 					'cells' => $cells,
 				];
 			},
-			$this->get_tag_content( $tbody, 'tr', false )
+			$this->get_tag_content( $section, 'tr', false )
 		);
 	}
 }

--- a/tests/unit/php/Blocks/TableTest.php
+++ b/tests/unit/php/Blocks/TableTest.php
@@ -10,7 +10,7 @@ use Badasswp\WPMockTC\WPMockTestCase;
 /**
  * @covers \ConvertBlocksToJSON\Blocks\Table::import_block
  * @covers \ConvertBlocksToJSON\Blocks\Table::export_block
- * @covers \ConvertBlocksToJSON\Blocks\Table::get_table_body
+ * @covers \ConvertBlocksToJSON\Blocks\Table::get_table_part
  * @covers \ConvertBlocksToJSON\Abstracts\Block::get_tag_content
  */
 class TableTest extends WPMockTestCase {
@@ -75,7 +75,7 @@ class TableTest extends WPMockTestCase {
 			$block,
 			[
 				'name'        => 'core/table',
-				'attributes'  => '{"content":"<table><tbody><tr><td>Cell 1a<\/td><td>Cell 1b<\/td><\/tr><tr><td>Cell 2a<\/td><td>Cell 2b<\/td><\/tr><\/tbody><\/table>","body":[{"cells":[{"content":"Cell 1a","tag":"td"},{"content":"Cell 1b","tag":"td"}]},{"cells":[{"content":"Cell 2a","tag":"td"},{"content":"Cell 2b","tag":"td"}]}]}',
+				'attributes'  => '{"content":"<table><tbody><tr><td>Cell 1a<\/td><td>Cell 1b<\/td><\/tr><tr><td>Cell 2a<\/td><td>Cell 2b<\/td><\/tr><\/tbody><\/table>","head":[],"body":[{"cells":[{"content":"Cell 1a","tag":"td"},{"content":"Cell 1b","tag":"td"}]},{"cells":[{"content":"Cell 2a","tag":"td"},{"content":"Cell 2b","tag":"td"}]}],"foot":[],"caption":""}',
 				'innerBlocks' => [],
 			]
 		);


### PR DESCRIPTION
This PR resolves [WP-138](https://appworld.atlassian.net/browse/WP-138).

## Description / Background Context

At the moment, when we import a Table block, we see the following issues:

- Table headers are not displaying.
- Multiple (`td`) columns with attributes are not appearing.
- Rendering inconsistency in test environment.

This PR implements a fix for this issue.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn install && yarn build`.
- Head over to `tastewp.com` [here](https://tastewp.com/create/NMS/8.0/6.7.0/convert-blocks-to-json/twentytwentythree?ni=true&origin=wp) and spin up a new WP instance.
- Now create a Table block by typing `/table` into the block editor (**make sure to put a text in the table cells**) and publish the post.
- Locate the `Convert Blocks to JSON` icon and export the blocks into a JSON file.
- (**For Engineers**) - Go back to your local environment and import the JSON file. (**For QA**) please use the [test](https://aw-wp-env.com/wp-admin/) server and import the JSON file.
- Observe that the Table block is now working correctly and all the issues mentioned above are now addressed.

---

<img width="742" height="740" alt="Screenshot 2026-02-26 at 10 11 24" src="https://github.com/user-attachments/assets/073628a9-0f38-4ec9-9750-91ae41e55217" />