### PR TITLE
Test: Add unit test for footnotes block

### DIFF
--- a/tests/unit/php/Blocks/FootnotesTest.php
+++ b/tests/unit/php/Blocks/FootnotesTest.php
@@ -120,8 +120,11 @@ class FootnotesTest extends WPMockTestCase {
 		$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/posts/42';
 
 		WP_Mock::userFunction( 'wp_parse_url' )
-			->with( '/wp-json/wp/v2/posts/42', PHP_URL_PATH )
-			->andReturn( '/wp-json/wp/v2/posts/42' );
+			->andReturnUsing(
+				function( $arg1, $arg2 ) {
+					return parse_url( $arg1, $arg2 );
+				}
+			);
 
 		WP_Mock::userFunction( 'absint' )
 			->with( '42' )

--- a/tests/unit/php/Blocks/FootnotesTest.php
+++ b/tests/unit/php/Blocks/FootnotesTest.php
@@ -117,7 +117,7 @@ class FootnotesTest extends WPMockTestCase {
 	}
 
 	public function test_export_block_returns_same_block_if_block_is_footnotes() {
-		$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/posts/42';
+		$_SERVER['REQUEST_URI'] = 'https://example.com/wp-json/wp/v2/posts/42';
 
 		WP_Mock::userFunction( 'wp_parse_url' )
 			->andReturnUsing(

--- a/tests/unit/php/Blocks/FootnotesTest.php
+++ b/tests/unit/php/Blocks/FootnotesTest.php
@@ -121,14 +121,10 @@ class FootnotesTest extends WPMockTestCase {
 
 		WP_Mock::userFunction( 'wp_parse_url' )
 			->andReturnUsing(
-				function( $arg1, $arg2 ) {
+				function ( $arg1, $arg2 ) {
 					return parse_url( $arg1, $arg2 );
 				}
 			);
-
-		WP_Mock::userFunction( 'absint' )
-			->with( '42' )
-			->andReturn( 42 );
 
 		WP_Mock::userFunction( 'get_post_meta' )
 			->with( 42, 'footnotes', true )

--- a/tests/unit/php/Blocks/FootnotesTest.php
+++ b/tests/unit/php/Blocks/FootnotesTest.php
@@ -151,8 +151,6 @@ class FootnotesTest extends WPMockTestCase {
 				'content'     => '',
 				'filtered'    => [],
 				'attributes'  => [
-					'content'   => 'Mr Zeks',
-					'id'        => '466e6cde-714f-412f-b95b-2a1852ff3471',
 					'footnotes' => '[{"content":"Mr Zeks","id":"466e6cde-714f-412f-b95b-2a1852ff3471"}]',
 				],
 				'innerBlocks' => [],

--- a/tests/unit/php/Blocks/FootnotesTest.php
+++ b/tests/unit/php/Blocks/FootnotesTest.php
@@ -139,10 +139,7 @@ class FootnotesTest extends WPMockTestCase {
 				'name'        => 'core/footnotes',
 				'content'     => '',
 				'filtered'    => [],
-				'attributes'  => [
-					'content' => 'Mr Zeks',
-					'id'      => '466e6cde-714f-412f-b95b-2a1852ff3471',
-				],
+				'attributes'  => [],
 				'innerBlocks' => [],
 			]
 		);

--- a/tests/unit/php/Blocks/FootnotesTest.php
+++ b/tests/unit/php/Blocks/FootnotesTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace ConvertBlocksToJSON\Tests\Blocks;
+
+use WP_Mock;
+use Mockery;
+use ConvertBlocksToJSON\Blocks\Footnotes;
+use Badasswp\WPMockTC\WPMockTestCase;
+
+/**
+ * @covers \ConvertBlocksToJSON\Blocks\Footnotes::import_block
+ * @covers \ConvertBlocksToJSON\Blocks\Footnotes::export_block
+ */
+class FootnotesTest extends WPMockTestCase {
+	public Footnotes $footnotes;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->footnotes = new Footnotes();
+	}
+
+	public function tearDown(): void {
+		unset( $_SERVER['REQUEST_URI'] );
+		parent::tearDown();
+	}
+
+	public function test_import_block_returns_default_block_if_name_is_undefined() {
+		$block = $this->footnotes->import_block(
+			[
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_import_block_returns_default_block_if_block_is_not_footnotes() {
+		$block = $this->footnotes->import_block(
+			[
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_import_block_returns_same_block_if_block_is_footnotes() {
+		$block = $this->footnotes->import_block(
+			[
+				'name'        => 'core/footnotes',
+				'attributes'  => '{"content":"Mr Zeks","id":"466e6cde-714f-412f-b95b-2a1852ff3471"}',
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'        => 'core/footnotes',
+				'attributes'  => '{"content":"Mr Zeks","id":"466e6cde-714f-412f-b95b-2a1852ff3471"}',
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_default_block_if_name_is_undefined() {
+		$block = $this->footnotes->export_block(
+			[
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_default_block_if_block_is_not_footnotes() {
+		$block = $this->footnotes->export_block(
+			[
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'        => 'core/paragraph',
+				'attributes'  => '{"content":""}',
+				'innerBlocks' => [],
+			]
+		);
+	}
+
+	public function test_export_block_returns_same_block_if_block_is_footnotes() {
+		$_SERVER['REQUEST_URI'] = '/wp-json/wp/v2/posts/42';
+
+		WP_Mock::userFunction( 'wp_parse_url' )
+			->with( '/wp-json/wp/v2/posts/42', PHP_URL_PATH )
+			->andReturn( '/wp-json/wp/v2/posts/42' );
+
+		WP_Mock::userFunction( 'absint' )
+			->with( '42' )
+			->andReturn( 42 );
+
+		WP_Mock::userFunction( 'get_post_meta' )
+			->with( 42, 'footnotes', true )
+			->andReturn( '[{"content":"Mr Zeks","id":"466e6cde-714f-412f-b95b-2a1852ff3471"}]' );
+
+		$block = $this->footnotes->export_block(
+			[
+				'name'        => 'core/footnotes',
+				'content'     => '',
+				'filtered'    => [],
+				'attributes'  => [
+					'content' => 'Mr Zeks',
+					'id'      => '466e6cde-714f-412f-b95b-2a1852ff3471',
+				],
+				'innerBlocks' => [],
+			]
+		);
+
+		$this->assertSame(
+			$block,
+			[
+				'name'        => 'core/footnotes',
+				'content'     => '',
+				'filtered'    => [],
+				'attributes'  => [
+					'content'   => 'Mr Zeks',
+					'id'        => '466e6cde-714f-412f-b95b-2a1852ff3471',
+					'footnotes' => '[{"content":"Mr Zeks","id":"466e6cde-714f-412f-b95b-2a1852ff3471"}]',
+				],
+				'innerBlocks' => [],
+			]
+		);
+	}
+}


### PR DESCRIPTION
This PR resolves [WP-140](https://appworld.atlassian.net/browse/WP-140).

## Description / Background Context

Now that we have implementation for the Footnotes block, we need to add unit tests to provide test coverage for the same block. This PR introduces basic unit tests for same.

## Testing Instructions

- Pull PR to local.
- Run `composer run test`.
- Observe that all test cases pass correctly.

---

<img width="1430" height="233" alt="Screenshot 2026-02-26 145013" src="https://github.com/user-attachments/assets/48658dc5-4525-4d29-9287-1006f3e791be" />
