### PR TITLE
Fix: Accordion import issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.0
+* Fix: Accordion import issues.
+
 ## 1.3.2
 * Tested up to WP 7.0
 

--- a/inc/Blocks/Accordion.php
+++ b/inc/Blocks/Accordion.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * AccordionHeading Block.
+ * Accordion Block.
  *
  * This class is responsible for customizing
- * the AccordionHeading block output.
+ * the Accordion block output.
  *
  * @package ConvertBlocksToJSON
  */
@@ -12,7 +12,7 @@ namespace ConvertBlocksToJSON\Blocks;
 
 use ConvertBlocksToJSON\Abstracts\Block;
 
-class AccordionHeading extends Block {
+class Accordion extends Block {
 
 	/**
 	 * Import Block.

--- a/inc/Blocks/AccordionHeading.php
+++ b/inc/Blocks/AccordionHeading.php
@@ -22,18 +22,6 @@ class AccordionHeading extends Block {
 	 * @param mixed[] $block Import Block.
 	 * @return mixed[]
 	 */
-	// public function import_block( $block ): array {
-	// 	if ( empty( $block['name'] ) || 'core/accordion-heading' !== $block['name'] ) {
-	// 		return $block;
-	// 	}
-
-	// 	// Title lives in `filtered`. Put it into attributes so JS can read it.
-	// 	$block['attributes'] = wp_json_encode( [
-	// 		'content' => $block['filtered'] ?? '',
-	// 	] );
-
-	// 	return $block;
-	// }
 	public function import_block( $block ): array {
 		// Bail out, if undefined OR not accordionHeading block.
 		if ( empty( $block['name'] ) || 'core/accordion-heading' !== $block['name'] ) {
@@ -44,7 +32,7 @@ class AccordionHeading extends Block {
 		$block['attributes'] = json_decode( $block['attributes'] ?? '{}', true );
 
 		$block['attributes']['content'] = $this->get_tag_content( $block['content'] ?? '', 'span' );
-		
+
 		// Re-encode attributes correctly.
 		$block['attributes'] = wp_json_encode( $block['attributes'] ?? [] );
 

--- a/inc/Blocks/AccordionHeading.php
+++ b/inc/Blocks/AccordionHeading.php
@@ -22,18 +22,6 @@ class AccordionHeading extends Block {
 	 * @param mixed[] $block Import Block.
 	 * @return mixed[]
 	 */
-	// public function import_block( $block ): array {
-	//  if ( empty( $block['name'] ) || 'core/accordion-heading' !== $block['name'] ) {
-	//      return $block;
-	//  }
-
-	//  // Title lives in `filtered`. Put it into attributes so JS can read it.
-	//  $block['attributes'] = wp_json_encode( [
-	//      'content' => $block['filtered'] ?? '',
-	//  ] );
-
-	//  return $block;
-	// }
 	public function import_block( $block ): array {
 		// Bail out, if undefined OR not accordionHeading block.
 		if ( empty( $block['name'] ) || 'core/accordion-heading' !== $block['name'] ) {

--- a/inc/Blocks/AccordionHeading.php
+++ b/inc/Blocks/AccordionHeading.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * AccordionHeading Block.
+ *
+ * This class is responsible for customizing
+ * the AccordionHeading block output.
+ *
+ * @package ConvertBlocksToJSON
+ */
+
+namespace ConvertBlocksToJSON\Blocks;
+
+use ConvertBlocksToJSON\Abstracts\Block;
+
+class AccordionHeading extends Block {
+
+	/**
+	 * Import Block.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param mixed[] $block Import Block.
+	 * @return mixed[]
+	 */
+	// public function import_block( $block ): array {
+	// 	if ( empty( $block['name'] ) || 'core/accordion-heading' !== $block['name'] ) {
+	// 		return $block;
+	// 	}
+
+	// 	// Title lives in `filtered`. Put it into attributes so JS can read it.
+	// 	$block['attributes'] = wp_json_encode( [
+	// 		'content' => $block['filtered'] ?? '',
+	// 	] );
+
+	// 	return $block;
+	// }
+	public function import_block( $block ): array {
+		// Bail out, if undefined OR not accordionHeading block.
+		if ( empty( $block['name'] ) || 'core/accordion-heading' !== $block['name'] ) {
+			return $block;
+		}
+
+		// Decode attributes correctly.
+		$block['attributes'] = json_decode( $block['attributes'] ?? '{}', true );
+
+		$block['attributes']['content'] = $this->get_tag_content( $block['content'] ?? '', 'span' );
+		
+		// Re-encode attributes correctly.
+		$block['attributes'] = wp_json_encode( $block['attributes'] ?? [] );
+
+		return $block;
+	}
+
+	/**
+	 * Export Block.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param mixed $block Export Block.
+	 * @return mixed[]
+	 */
+	public function export_block( $block ): array {
+		// Bail out, if undefined OR not accordionHeading block.
+		if ( empty( $block['name'] ) || 'core/accordion-heading' !== $block['name'] ) {
+			return $block;
+		}
+
+		return $block;
+	}
+}

--- a/inc/Blocks/AccordionHeading.php
+++ b/inc/Blocks/AccordionHeading.php
@@ -23,16 +23,16 @@ class AccordionHeading extends Block {
 	 * @return mixed[]
 	 */
 	// public function import_block( $block ): array {
-	// 	if ( empty( $block['name'] ) || 'core/accordion-heading' !== $block['name'] ) {
-	// 		return $block;
-	// 	}
+	//  if ( empty( $block['name'] ) || 'core/accordion-heading' !== $block['name'] ) {
+	//      return $block;
+	//  }
 
-	// 	// Title lives in `filtered`. Put it into attributes so JS can read it.
-	// 	$block['attributes'] = wp_json_encode( [
-	// 		'content' => $block['filtered'] ?? '',
-	// 	] );
+	//  // Title lives in `filtered`. Put it into attributes so JS can read it.
+	//  $block['attributes'] = wp_json_encode( [
+	//      'content' => $block['filtered'] ?? '',
+	//  ] );
 
-	// 	return $block;
+	//  return $block;
 	// }
 	public function import_block( $block ): array {
 		// Bail out, if undefined OR not accordionHeading block.
@@ -44,7 +44,7 @@ class AccordionHeading extends Block {
 		$block['attributes'] = json_decode( $block['attributes'] ?? '{}', true );
 
 		$block['attributes']['content'] = $this->get_tag_content( $block['content'] ?? '', 'span' );
-		
+
 		// Re-encode attributes correctly.
 		$block['attributes'] = wp_json_encode( $block['attributes'] ?? [] );
 

--- a/inc/Services/Blocks.php
+++ b/inc/Services/Blocks.php
@@ -11,6 +11,7 @@
 namespace ConvertBlocksToJSON\Services;
 
 use ConvertBlocksToJSON\Blocks\Audio;
+use ConvertBlocksToJSON\Blocks\AccordionHeading;
 use ConvertBlocksToJSON\Blocks\Details;
 use ConvertBlocksToJSON\Blocks\Footnotes;
 use ConvertBlocksToJSON\Blocks\Freeform;
@@ -48,6 +49,7 @@ class Blocks extends Service implements Kernel {
 	public function __construct() {
 		$this->blocks = [
 			Audio::class,
+			AccordionHeading::class,
 			Details::class,
 			Footnotes::class,
 			Freeform::class,

--- a/inc/Services/Blocks.php
+++ b/inc/Services/Blocks.php
@@ -48,8 +48,8 @@ class Blocks extends Service implements Kernel {
 	 */
 	public function __construct() {
 		$this->blocks = [
-			Audio::class,
 			Accordion::class,
+			Audio::class,
 			Details::class,
 			Footnotes::class,
 			Freeform::class,

--- a/inc/Services/Blocks.php
+++ b/inc/Services/Blocks.php
@@ -11,7 +11,7 @@
 namespace ConvertBlocksToJSON\Services;
 
 use ConvertBlocksToJSON\Blocks\Audio;
-use ConvertBlocksToJSON\Blocks\AccordionHeading;
+use ConvertBlocksToJSON\Blocks\Accordion;
 use ConvertBlocksToJSON\Blocks\Details;
 use ConvertBlocksToJSON\Blocks\Footnotes;
 use ConvertBlocksToJSON\Blocks\Freeform;
@@ -49,7 +49,7 @@ class Blocks extends Service implements Kernel {
 	public function __construct() {
 		$this->blocks = [
 			Audio::class,
-			AccordionHeading::class,
+			Accordion::class,
 			Details::class,
 			Footnotes::class,
 			Freeform::class,

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,9 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.4.0 =
+* Fix: Accordion import issues.
+
 = 1.3.2 =
 * Tested up to WP 7.0
 

--- a/src/filters.tsx
+++ b/src/filters.tsx
@@ -35,6 +35,20 @@ addAction( 'cbtj.afterImport', 'cbtj', async ( { blocks } ) => {
 } );
 
 /**
+ * Recursively creates blocks from a block definition,
+ * including nested innerBlocks at any depth.
+ * @param blockDef
+ */
+const createBlockRecursive = ( blockDef: any ): any => {
+	const { name, attributes, innerBlocks = [] } = blockDef;
+
+	const parsedAttributes = attributes ? JSON.parse( attributes ) : {};
+	const children = innerBlocks.map( createBlockRecursive );
+
+	return createBlock( name, parsedAttributes, children );
+};
+
+/**
  * Filter the way we handle the innerBlocks
  * depending on the type of block.
  *
@@ -54,10 +68,9 @@ addFilter( 'cbtj.innerBlocks', 'cbtj', ( innerBlocks, block ) => {
 		case 'core/details':
 		case 'core/media-text':
 		case 'core/gallery':
+		case 'core/accordion':
 		case 'core/cover':
-			blocks = innerBlocks.map( ( { name, attributes } ) =>
-				createBlock( name, { ...JSON.parse( attributes ) } )
-			);
+			blocks = innerBlocks.map( createBlockRecursive );
 			break;
 
 		default:

--- a/src/filters.tsx
+++ b/src/filters.tsx
@@ -68,8 +68,12 @@ addFilter( 'cbtj.innerBlocks', 'cbtj', ( innerBlocks, block ) => {
 		case 'core/details':
 		case 'core/media-text':
 		case 'core/gallery':
-		case 'core/accordion':
 		case 'core/cover':
+			blocks = innerBlocks.map( ( { name, attributes } ) =>
+				createBlock( name, { ...JSON.parse( attributes ) } )
+			);
+			break;
+		case 'core/accordion':
 			blocks = innerBlocks.map( createBlockRecursive );
 			break;
 

--- a/tests/unit/php/Services/BlocksTest.php
+++ b/tests/unit/php/Services/BlocksTest.php
@@ -8,6 +8,7 @@ use Badasswp\WPMockTC\WPMockTestCase;
 use ConvertBlocksToJSON\Abstracts\Block;
 use ConvertBlocksToJSON\Services\Blocks;
 
+use ConvertBlocksToJSON\Blocks\Accordion;
 use ConvertBlocksToJSON\Blocks\Audio;
 use ConvertBlocksToJSON\Blocks\Details;
 use ConvertBlocksToJSON\Blocks\Footnotes;
@@ -44,6 +45,7 @@ class BlocksTest extends WPMockTestCase {
 	public function test_class_properties_are_defined_by_default() {
 		$this->assertSame(
 			[
+				Accordion::class,
 				Audio::class,
 				Details::class,
 				Footnotes::class,
@@ -94,6 +96,7 @@ class BlocksTest extends WPMockTestCase {
 		WP_Mock::expectFilter(
 			'cbtj_blocks',
 			[
+				Accordion::class,
 				Audio::class,
 				Details::class,
 				Footnotes::class,


### PR DESCRIPTION
This PR resolves [WP-146](https://appworld.atlassian.net/browse/WP-146)

## Description / Background Context


At the moment, when we import an Accordion block, we see that the block does not import correctly as expected. The text typed into the Accordion block does NOT appear after import. The expected behaviour should be that it appears and shows on the Accordion block.

This PR implements a fix for this issue.

## Testing Instructions

- Pull PR to local.
- Build correctly using `yarn install` && `yarn build`.
- Add an accordion block in a new post.
- Publish the post and then export it.
- Open a new post and import the `json` file exported.
- Observe that the accordion block is exported correctly except for the Accordion title as seen below.


## Screenshots / Screencast

<img width="626" height="305" alt="Screenshot 2026-06-04 113551" src="https://github.com/user-attachments/assets/a79e7d30-fb04-4052-8992-1473c571ce7b" />
