### PR TITLE
Feat: Restrict Non JSON files during import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.0
+* Feat: Restrict `non-json` files during import.
+
 ## 1.3.2
 * Tested up to WP 7.0
 

--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,9 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= 1.4.0 =
+* Feat: Restrict `non-json` files during import.
+
 = 1.3.2 =
 * Tested up to WP 7.0
 

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -62,6 +62,9 @@ export const getModalParams = (): any => {
 			text: __( 'Use JSON', 'convert-blocks-to-json' ),
 		},
 		multiple: false,
+		library: {
+			type: 'application/json',
+		},
 	};
 };
 

--- a/tests/unit/js/Args.test.tsx
+++ b/tests/unit/js/Args.test.tsx
@@ -89,6 +89,9 @@ describe( 'Utilities', () => {
 				text: 'Use JSON',
 			},
 			multiple: false,
+			library: {
+				type: 'application/json',
+			},
 		} );
 	} );
 


### PR DESCRIPTION
This PR resolves [WP-137](https://appworld.atlassian.net/browse/WP-137)

## Description / Background Context

Currently, during import, users can select a `non-json` files in the media library, we don't want that. We want that only `json` files can be selected from the media library.This PR resolves that issue.

## Testing Instructions

- Pull PR to local.
- Run the following command `yarn build`.
- Proceed to adding a new post, and select `import JSON` .
- Observe that only `json` files in your media library are available for selection.

## Screenshots / Screencast


---

Before

----
<img width="922" height="401" alt="Screenshot 2026-06-23 144511" src="https://github.com/user-attachments/assets/dca63015-bd82-46ba-8103-be9d84e89d2e" />



---

Now 

---
<img width="920" height="397" alt="Screenshot 2026-06-23 144658" src="https://github.com/user-attachments/assets/878ca5a2-f8ff-4a0f-8ba9-e37c50b2310a" />
